### PR TITLE
chore(ci): versioned deploy workflow (deploy from git ref)

### DIFF
--- a/.github/workflows/deploy-from-ref.yml
+++ b/.github/workflows/deploy-from-ref.yml
@@ -1,0 +1,160 @@
+name: Deploy From Ref (Versioned/Rollback)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to deploy (tag, branch, or commit SHA)"
+        required: true
+        type: string
+      stage:
+        description: "Serverless stage to deploy (e.g., prod, staging)"
+        required: true
+        default: "prod"
+        type: choice
+        options:
+          - prod
+          - staging
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: us-east-1
+      STAGE: ${{ inputs.stage }}
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: github-actions-deploy-from-ref
+
+      - name: Install Serverless
+        run: npm i -g serverless@3
+
+      - name: Ensure Google OAuth SSM parameters exist
+        env:
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          if ! aws ssm get-parameter --name "/bookclub/oauth/google_client_id" >/dev/null 2>&1; then
+            aws ssm put-parameter \
+              --name "/bookclub/oauth/google_client_id" \
+              --type String \
+              --value "$GOOGLE_CLIENT_ID"
+          fi
+          if ! aws ssm get-parameter --name "/bookclub/oauth/google_client_secret" --with-decryption >/dev/null 2>&1; then
+            aws ssm put-parameter \
+              --name "/bookclub/oauth/google_client_secret" \
+              --type SecureString \
+              --value "$GOOGLE_CLIENT_SECRET"
+          fi
+
+      - name: Backend deps
+        working-directory: bookclub-app/backend
+        run: npm ci
+
+      - name: Deploy backend (Serverless)
+        working-directory: bookclub-app/backend
+        env:
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+        run: npx serverless deploy --stage ${{ env.STAGE }}
+
+      - name: Check CloudFormation stack status
+        working-directory: bookclub-app/backend
+        run: |
+          set -euo pipefail
+          STACK_NAME="bookclub-app-${{ env.STAGE }}"
+          STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --query 'Stacks[0].StackStatus' --output text || echo "")
+          echo "StackStatus=$STATUS"
+          if [ -z "$STATUS" ]; then
+            echo "Stack $STACK_NAME not found. The deploy step may have failed before stack creation." >&2
+            exit 1
+          fi
+          case "$STATUS" in
+            *_IN_PROGRESS) echo "Stack update in progress; continuing" ;;
+            *_COMPLETE) echo "Stack is complete: $STATUS" ;;
+            *)
+              echo "Stack is in error state: $STATUS" >&2
+              aws cloudformation describe-stack-events --stack-name "$STACK_NAME" --max-items 15 --output table || true
+              exit 1
+              ;;
+          esac
+
+      - name: Detect API URL (prefer custom domain, fallback to execute-api)
+        id: detect_api
+        working-directory: bookclub-app/backend
+        run: |
+          set -euo pipefail
+          STAGE="${{ env.STAGE }}"
+          EXEC_API=$(aws cloudformation describe-stacks --stack-name bookclub-app-$STAGE \
+            --query "Stacks[0].Outputs[?OutputKey=='ServiceEndpoint'].OutputValue | [0]" --output text 2>/dev/null | sed 's/None//')
+          if [ -z "${EXEC_API}" ]; then
+            EXEC_API=$(npx serverless info --stage "$STAGE" --verbose | awk '/ServiceEndpoint:/{print $2; exit}' || echo "")
+          fi
+          if [ -z "$EXEC_API" ]; then
+            REST_API_ID=$(aws cloudformation list-exports --query "Exports[?Name=='bookclub-app-$STAGE-RestApiId'].Value | [0]" --output text || echo "")
+            if [ -n "$REST_API_ID" ] && [ "$REST_API_ID" != "None" ]; then
+              EXEC_API="https://${REST_API_ID}.execute-api.${AWS_REGION}.amazonaws.com/$STAGE"
+            else
+              echo "Failed to detect ServiceEndpoint." >&2
+              exit 1
+            fi
+          fi
+          echo "API_URL=$EXEC_API" | tee -a "$GITHUB_ENV"
+
+      - name: Build frontend
+        working-directory: bookclub-app/frontend
+        env:
+          REACT_APP_API_URL: ${{ env.API_URL }}
+          REACT_APP_COGNITO_REGION: us-east-1
+          REACT_APP_COGNITO_USER_POOL_ID: ${{ env.REACT_APP_COGNITO_USER_POOL_ID }}
+          REACT_APP_COGNITO_CLIENT_ID: ${{ env.REACT_APP_COGNITO_CLIENT_ID }}
+          REACT_APP_COGNITO_DOMAIN: ${{ env.REACT_APP_COGNITO_DOMAIN }}
+          REACT_APP_OAUTH_REDIRECT_SIGNIN: https://booklub.shop/auth/callback
+          REACT_APP_OAUTH_REDIRECT_SIGNOUT: https://booklub.shop/
+          REACT_APP_OAUTH_SCOPES: "openid email profile"
+        run: |
+          npm ci
+          npm run build
+
+      - name: Upload frontend to S3 (versioned path)
+        env:
+          FRONTEND_S3_BUCKET: ${{ secrets.FRONTEND_S3_BUCKET }}
+        run: |
+          set -euo pipefail
+          REF="${{ inputs.ref }}"
+          SAFE_REF=$(echo "$REF" | tr '/' '-' )
+          PREFIX="versions/$SAFE_REF/"
+          echo "Uploading build to s3://$FRONTEND_S3_BUCKET/$PREFIX"
+          aws s3 sync bookclub-app/frontend/build s3://$FRONTEND_S3_BUCKET/$PREFIX --delete
+          echo "PREVIEW_URL=https://booklub.shop/$PREFIX" | tee -a "$GITHUB_ENV"
+
+      - name: Invalidate CloudFront (optional)
+        if: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID != '' }}
+        env:
+          DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths "/versions/*"
+
+      - name: Post deployment URL to summary
+        run: |
+          echo "Deployed ref ${{ inputs.ref }} to stage ${{ inputs.stage }}" >> $GITHUB_STEP_SUMMARY
+          echo "Frontend URL: $PREVIEW_URL" >> $GITHUB_STEP_SUMMARY

--- a/bookclub-app/frontend/public/architecture.svg
+++ b/bookclub-app/frontend/public/architecture.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="960" height="520" viewBox="0 0 960 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .title{font: 700 18px sans-serif; fill:#111827}
+      .label{font: 600 14px sans-serif; fill:#111827}
+      .small{font: 500 12px sans-serif; fill:#374151}
+      .box{fill:#ffffff; stroke:#374151; stroke-width:2; rx:10; ry:10}
+      .arrow{stroke:#4F46E5; stroke-width:2; marker-end:url(#arrowhead)}
+      .arrowGray{stroke:#6B7280; stroke-dasharray:4 4; stroke-width:2; marker-end:url(#arrowheadGray)}
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#4F46E5" />
+    </marker>
+    <marker id="arrowheadGray" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6B7280" />
+    </marker>
+  </defs>
+
+  <text x="30" y="40" class="title">Book Club - Serverless Architecture</text>
+
+  <!-- Client -->
+  <rect x="40" y="80" width="180" height="80" class="box"/>
+  <text x="60" y="120" class="label">Client (React App)</text>
+  <text x="60" y="140" class="small">Browser</text>
+
+  <!-- API Gateway -->
+  <rect x="280" y="80" width="200" height="80" class="box"/>
+  <text x="300" y="120" class="label">Amazon API Gateway</text>
+  <text x="300" y="140" class="small">REST endpoints</text>
+
+  <!-- Lambda -->
+  <rect x="540" y="80" width="180" height="80" class="box"/>
+  <text x="560" y="120" class="label">AWS Lambda</text>
+  <text x="560" y="140" class="small">Business logic</text>
+
+  <!-- DynamoDB -->
+  <rect x="780" y="40" width="160" height="80" class="box"/>
+  <text x="800" y="80" class="label">Amazon DynamoDB</text>
+
+  <!-- S3 -->
+  <rect x="780" y="150" width="160" height="80" class="box"/>
+  <text x="820" y="190" class="label">Amazon S3</text>
+  
+  <!-- Textract -->
+  <rect x="540" y="210" width="180" height="80" class="box"/>
+  <text x="560" y="250" class="label">Amazon Textract</text>
+  <text x="560" y="270" class="small">OCR for book covers</text>
+
+  <!-- Flows -->
+  <line x1="220" y1="120" x2="280" y2="120" class="arrow"/>
+  <text x="230" y="110" class="small">HTTPS</text>
+
+  <line x1="480" y1="120" x2="540" y2="120" class="arrow"/>
+  <text x="490" y="110" class="small">Invoke</text>
+
+  <line x1="720" y1="120" x2="780" y2="80" class="arrow"/>
+  <text x="730" y="95" class="small">CRUD</text>
+
+  <line x1="720" y1="120" x2="780" y2="190" class="arrow"/>
+  <text x="730" y="165" class="small">Upload</text>
+
+  <line x1="630" y1="160" x2="630" y2="210" class="arrowGray"/>
+  <text x="640" y="190" class="small">Analyze</text>
+
+  <!-- Notes -->
+  <text x="40" y="220" class="small">Flow:</text>
+  <text x="40" y="240" class="small">1) Client calls API Gateway</text>
+  <text x="40" y="260" class="small">2) API Gateway invokes Lambda</text>
+  <text x="40" y="280" class="small">3) Lambda reads/writes to DynamoDB</text>
+  <text x="40" y="300" class="small">4) Lambda puts/gets objects from S3</text>
+  <text x="40" y="320" class="small">5) Lambda optionally calls Textract for OCR</text>
+</svg>

--- a/bookclub-app/frontend/src/App.tsx
+++ b/bookclub-app/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import Login from './pages/Login';
 import AuthCallback from './pages/AuthCallback';
 import ProfileEdit from './pages/ProfileEdit';
 import BookLibrary from './pages/BookLibrary';
+import About from './pages/About';
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
                 <Routes>
                   <Route path="/login" element={<Login />} />
                   <Route path="/register" element={<Navigate to="/login" replace />} />
+                  <Route path="/about" element={<About />} />
                   <Route path="/auth/callback" element={<AuthCallback />} />
                   <Route path="/library" element={<BookLibrary />} />
                   <Route

--- a/bookclub-app/frontend/src/App.tsx
+++ b/bookclub-app/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { AuthProvider } from './contexts/AuthContext';
 import { NotificationProvider } from './contexts/NotificationContext';
 import Navbar from './components/Navbar';
+import Sidebar from './components/Sidebar';
 import ProtectedRoute from './components/ProtectedRoute';
 import Home from './pages/Home';
 import Login from './pages/Login';
@@ -17,29 +18,42 @@ function App() {
         <AuthProvider>
           <div className="App">
             <Navbar />
-            <Routes>
-              <Route path="/login" element={<Login />} />
-              <Route path="/register" element={<Navigate to="/login" replace />} />
-              <Route path="/auth/callback" element={<AuthCallback />} />
-              <Route path="/library" element={<BookLibrary />} />
-              <Route
-                path="/"
-                element={
-                  <ProtectedRoute>
-                    <Home />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/profile"
-                element={
-                  <ProtectedRoute>
-                    <ProfileEdit />
-                  </ProtectedRoute>
-                }
-              />
-              <Route path="*" element={<Navigate to="/" />} />
-            </Routes>
+            <div className="flex">
+              <Sidebar />
+              <main className="flex-1 min-h-screen bg-gray-50">
+                <Routes>
+                  <Route path="/login" element={<Login />} />
+                  <Route path="/register" element={<Navigate to="/login" replace />} />
+                  <Route path="/auth/callback" element={<AuthCallback />} />
+                  <Route path="/library" element={<BookLibrary />} />
+                  <Route
+                    path="/"
+                    element={
+                      <ProtectedRoute>
+                        <Home />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/my-books"
+                    element={
+                      <ProtectedRoute>
+                        <Home />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/profile"
+                    element={
+                      <ProtectedRoute>
+                        <ProfileEdit />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route path="*" element={<Navigate to="/" />} />
+                </Routes>
+              </main>
+            </div>
           </div>
         </AuthProvider>
       </NotificationProvider>

--- a/bookclub-app/frontend/src/components/Navbar.tsx
+++ b/bookclub-app/frontend/src/components/Navbar.tsx
@@ -17,14 +17,15 @@ const Navbar: React.FC = () => {
                 className="h-8 w-auto"
               />
             </Link>
-            
-            {/* Public Library Link */}
-            <Link
-              to="/library"
-              className="ml-8 text-indigo-600 hover:text-indigo-800 px-3 py-2 rounded-md text-sm font-medium border border-indigo-200 hover:border-indigo-300 transition-colors"
-            >
-              📚 Our Library
-            </Link>
+            {!isAuthenticated && (
+              // Public Library link shown only when not signed in; moved to Sidebar for signed-in users
+              <Link
+                to="/library"
+                className="ml-8 text-indigo-600 hover:text-indigo-800 px-3 py-2 rounded-md text-sm font-medium border border-indigo-200 hover:border-indigo-300 transition-colors"
+              >
+                📚 Our Library
+              </Link>
+            )}
           </div>
           
           <div className="flex items-center space-x-4">

--- a/bookclub-app/frontend/src/components/Navbar.tsx
+++ b/bookclub-app/frontend/src/components/Navbar.tsx
@@ -26,6 +26,12 @@ const Navbar: React.FC = () => {
                 📚 Our Library
               </Link>
             )}
+            <Link
+              to="/about"
+              className="ml-4 text-gray-700 hover:text-gray-900 px-3 py-2 rounded-md text-sm font-medium"
+            >
+              About
+            </Link>
           </div>
           
           <div className="flex items-center space-x-4">

--- a/bookclub-app/frontend/src/components/Sidebar.tsx
+++ b/bookclub-app/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+const Sidebar: React.FC = () => {
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) return null;
+
+  const baseLink = 'flex items-center px-3 py-2 rounded-md text-sm font-medium';
+  const active = 'bg-indigo-600 text-white';
+  const inactive = 'text-gray-700 hover:bg-gray-100';
+
+  return (
+    <aside className="w-56 bg-white border-r border-gray-200 p-4 hidden md:block">
+      <nav className="space-y-1">
+        <NavLink
+          to="/library"
+          className={({ isActive }) => `${baseLink} ${isActive ? active : inactive}`}
+        >
+          📚 Browse Our Library
+        </NavLink>
+        <NavLink
+          to="/"
+          end
+          className={({ isActive }) => `${baseLink} ${isActive ? active : inactive}`}
+        >
+          All Books
+        </NavLink>
+        <NavLink
+          to="/my-books"
+          className={({ isActive }) => `${baseLink} ${isActive ? active : inactive}`}
+        >
+          My Books
+        </NavLink>
+      </nav>
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/bookclub-app/frontend/src/pages/About.tsx
+++ b/bookclub-app/frontend/src/pages/About.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+const About: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-gray-50 py-10 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-5xl mx-auto space-y-8">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold text-gray-900">About Us</h1>
+          <p className="text-gray-700">
+            Book Club is a serverless web application that helps readers discover and manage books with a simple, modern interface.
+          </p>
+        </header>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold text-gray-900">Architecture</h2>
+          <p className="text-gray-700">
+            Our architecture leverages AWS managed services for scalability and low operational overhead. Below is a high-level overview of the data flow involving
+            API Gateway, AWS Lambda, Amazon DynamoDB, Amazon S3, and Amazon Textract.
+          </p>
+          <div className="bg-white border rounded-lg p-4">
+            <img
+              src="/architecture.svg"
+              alt="System Architecture Diagram"
+              className="w-full h-auto"
+            />
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-2xl font-semibold text-gray-900">Links</h2>
+          <ul className="list-disc list-inside text-gray-700">
+            <li>
+              GitHub: <a className="text-indigo-600 hover:text-indigo-800 underline" href="https://github.com/pedaganim" target="_blank" rel="noreferrer">https://github.com/pedaganim</a>
+            </li>
+          </ul>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default About;

--- a/bookclub-app/frontend/src/pages/Home.tsx
+++ b/bookclub-app/frontend/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 import { Book, BookClub } from '../types';
 import { apiService } from '../services/api';
@@ -29,6 +30,8 @@ const Home: React.FC = () => {
   const [showCreateClubModal, setShowCreateClubModal] = useState(false);
   const [showJoinClubModal, setShowJoinClubModal] = useState(false);
   const [filter, setFilter] = useState<'all' | 'my-books'>('all');
+  const location = useLocation();
+  const navigate = useNavigate();
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [activeTab, setActiveTab] = useState<'books' | 'clubs'>('books');
   const [searchQuery, setSearchQuery] = useState('');
@@ -88,6 +91,13 @@ const Home: React.FC = () => {
     setPreviousTokens([]);
     setNextToken(null);
     setCurrentPageToken(null);
+    // Navigate to keep URL and UI in sync
+    if (newFilter === 'my-books') {
+      navigate('/my-books');
+    } else {
+      navigate('/');
+    }
+    fetchBooks(searchQuery || undefined, pageSize, null);
   };
 
   const handlePageSizeChange = (newPageSize: number) => {
@@ -137,6 +147,16 @@ const Home: React.FC = () => {
     fetchBooks();
     fetchClubs();
   }, [fetchBooks, fetchClubs]);
+
+  // Keep filter in sync with current route
+  useEffect(() => {
+    if (location.pathname === '/my-books' && filter !== 'my-books') {
+      setFilter('my-books');
+    } else if (location.pathname === '/' && filter !== 'all') {
+      setFilter('all');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname]);
 
   const handleBookAdded = (newBook: Book) => {
     setBooks([newBook, ...books]);

--- a/bookclub-app/frontend/src/services/ocrService.ts
+++ b/bookclub-app/frontend/src/services/ocrService.ts
@@ -1,4 +1,5 @@
 import { createWorker } from 'tesseract.js';
+import type { Worker as TesseractWorker } from 'tesseract.js';
 
 export interface OCRResult {
   text: string;
@@ -39,7 +40,7 @@ interface PreprocessingOptions {
 }
 
 class OCRService {
-  private worker: Tesseract.Worker | null = null;
+  private worker: TesseractWorker | null = null;
   private isInitialized = false;
 
   /**


### PR DESCRIPTION
This PR introduces a reusable GitHub Actions workflow to deploy any git ref (tags/branches/SHAs) to a chosen Serverless stage.\n\nHighlights\n- Manual trigger via `workflow_dispatch` with inputs: `ref` and `stage` (prod/staging).\n- Checks out the specified ref, deploys backend with Serverless, builds the frontend with detected API URL, and uploads to S3 under a versioned prefix (`versions/<ref>/`).\n- Posts the resulting URL to the job summary.\n\nUsage\n- Go to Actions → "Deploy From Ref (Versioned/Rollback)" → Run workflow.\n- Enter a tag (e.g., `v1.2.3`), branch name, or commit SHA, and select stage.\n\nNotes\n- Requires existing OIDC role (`vars.AWS_OIDC_ROLE_ARN`) and S3/CloudFront secrets.\n- Frontend OAuth redirects are still pointing to prod domain; adjust if needed for non-prod stages.\n