### PR TITLE
Bedrock throttling: reduce worker concurrency to 1; increase backoff …

### DIFF
--- a/bookclub-app/backend/serverless.yml
+++ b/bookclub-app/backend/serverless.yml
@@ -36,6 +36,10 @@ provider:
     BEDROCK_ANALYZE_QUEUE_URL: !Ref BedrockAnalyzeQueue
     # Base URL for generating absolute links in sitemap
     SITE_BASE_URL: ${env:SITE_BASE_URL, 'https://booklub.shop'}
+    # Bedrock throttle tuning
+    BEDROCK_MAX_ATTEMPTS: ${env:BEDROCK_MAX_ATTEMPTS, '8'}
+    BEDROCK_BACKOFF_BASE_MS: ${env:BEDROCK_BACKOFF_BASE_MS, '1000'} # start at 1s (was 500ms)
+    BEDROCK_BACKOFF_MAX_MS: ${env:BEDROCK_BACKOFF_MAX_MS, '30000'}  # cap at 30s (was 15s)
   iam:
     role:
       statements:
@@ -195,7 +199,7 @@ functions:
       - sqs:
           arn: !GetAtt BedrockAnalyzeQueue.Arn
           batchSize: 1
-          maximumConcurrency: 2
+          maximumConcurrency: 1
 
   getUserPublic:
     handler: src/handlers/users/getById.handler


### PR DESCRIPTION
…base to 1s and cap to 30s; expose env knobs.