### PR TITLE
feat: implement Swap Toys marketplace

### DIFF
--- a/bookclub-app/backend/__tests__/unit/handlers/swaptoys/create.test.js
+++ b/bookclub-app/backend/__tests__/unit/handlers/swaptoys/create.test.js
@@ -1,0 +1,89 @@
+const handler = require('../../../../src/handlers/swaptoys/create').handler;
+
+jest.mock('../../../../src/models/toyListing');
+const mockToyListing = require('../../../../src/models/toyListing');
+
+const mockEvent = (body, userId = 'user-123') => ({
+  requestContext: {
+    authorizer: {
+      claims: { sub: userId },
+    },
+  },
+  body: JSON.stringify(body),
+});
+
+describe('Create Toy Listing Handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should create a listing and return 201', async () => {
+    const mockListing = {
+      listingId: 'abc-123',
+      userId: 'user-123',
+      title: 'Wooden Train Set',
+      condition: 'good',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    mockToyListing.create = jest.fn().mockResolvedValue(mockListing);
+
+    const result = await handler(mockEvent({ title: 'Wooden Train Set', condition: 'good' }));
+
+    expect(result.statusCode).toBe(201);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.data.title).toBe('Wooden Train Set');
+    expect(mockToyListing.create).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Wooden Train Set', condition: 'good' }),
+      'user-123'
+    );
+  });
+
+  it('should return 400 when title is missing', async () => {
+    const result = await handler(mockEvent({ condition: 'good' }));
+
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error.errors.title).toBeDefined();
+  });
+
+  it('should return 400 when condition is invalid', async () => {
+    const result = await handler(mockEvent({ title: 'Train Set', condition: 'terrible' }));
+
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error.errors.condition).toBeDefined();
+  });
+
+  it('should return 400 when category is invalid', async () => {
+    const result = await handler(mockEvent({ title: 'Train Set', condition: 'good', category: 'not-a-category' }));
+
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error.errors.category).toBeDefined();
+  });
+
+  it('should return 401 when no userId in token', async () => {
+    const event = {
+      requestContext: { authorizer: { claims: {} } },
+      body: JSON.stringify({ title: 'Train Set', condition: 'good' }),
+    };
+    const result = await handler(event);
+
+    expect(result.statusCode).toBe(401);
+  });
+
+  it('should return 500 on unexpected error', async () => {
+    mockToyListing.create = jest.fn().mockRejectedValue(new Error('DB error'));
+
+    const result = await handler(mockEvent({ title: 'Train Set', condition: 'good' }));
+
+    expect(result.statusCode).toBe(500);
+  });
+});

--- a/bookclub-app/backend/__tests__/unit/handlers/swaptoys/delete.test.js
+++ b/bookclub-app/backend/__tests__/unit/handlers/swaptoys/delete.test.js
@@ -1,0 +1,80 @@
+const handler = require('../../../../src/handlers/swaptoys/delete').handler;
+
+jest.mock('../../../../src/models/toyListing');
+const mockToyListing = require('../../../../src/models/toyListing');
+
+const mockEvent = (listingId, userId = 'user-123') => ({
+  requestContext: {
+    authorizer: {
+      claims: { sub: userId },
+    },
+  },
+  pathParameters: { listingId },
+});
+
+describe('Delete Toy Listing Handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should delete listing and return 200', async () => {
+    mockToyListing.delete = jest.fn().mockResolvedValue({ success: true });
+
+    const result = await handler(mockEvent('listing-123'));
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.data.deleted).toBe(true);
+    expect(mockToyListing.delete).toHaveBeenCalledWith('listing-123', 'user-123');
+  });
+
+  it('should return 401 when no userId', async () => {
+    const event = {
+      requestContext: { authorizer: { claims: {} } },
+      pathParameters: { listingId: 'listing-123' },
+    };
+    const result = await handler(event);
+
+    expect(result.statusCode).toBe(401);
+  });
+
+  it('should return 400 when listingId is missing', async () => {
+    const event = {
+      requestContext: { authorizer: { claims: { sub: 'user-123' } } },
+      pathParameters: {},
+    };
+    const result = await handler(event);
+
+    expect(result.statusCode).toBe(400);
+  });
+
+  it('should return 403 when not owner', async () => {
+    mockToyListing.delete = jest.fn().mockRejectedValue(new Error('Not authorised'));
+
+    const result = await handler(mockEvent('listing-123', 'other-user'));
+
+    expect(result.statusCode).toBe(403);
+  });
+
+  it('should return 404 when listing does not exist', async () => {
+    mockToyListing.delete = jest.fn().mockRejectedValue(new Error('Listing not found'));
+
+    const result = await handler(mockEvent('bad-id'));
+
+    expect(result.statusCode).toBe(404);
+  });
+
+  it('should return 500 on unexpected error', async () => {
+    mockToyListing.delete = jest.fn().mockRejectedValue(new Error('DB error'));
+
+    const result = await handler(mockEvent('listing-123'));
+
+    expect(result.statusCode).toBe(500);
+  });
+});

--- a/bookclub-app/backend/__tests__/unit/handlers/swaptoys/list.test.js
+++ b/bookclub-app/backend/__tests__/unit/handlers/swaptoys/list.test.js
@@ -1,0 +1,69 @@
+const handler = require('../../../../src/handlers/swaptoys/list').handler;
+
+jest.mock('../../../../src/models/toyListing');
+const mockToyListing = require('../../../../src/models/toyListing');
+
+describe('List Toy Listings Handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const mockListings = [
+    { listingId: 'abc-1', title: 'Train Set', condition: 'good' },
+    { listingId: 'abc-2', title: 'Lego Set', condition: 'like_new' },
+  ];
+
+  it('should list all listings without filters', async () => {
+    mockToyListing.listAll = jest.fn().mockResolvedValue({ items: mockListings, nextToken: null });
+
+    const result = await handler({ queryStringParameters: null });
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.success).toBe(true);
+    expect(body.data.items).toHaveLength(2);
+    expect(mockToyListing.listAll).toHaveBeenCalled();
+    expect(mockToyListing.listByUser).not.toHaveBeenCalled();
+  });
+
+  it('should list by userId when userId query param is provided', async () => {
+    mockToyListing.listByUser = jest.fn().mockResolvedValue({ items: [mockListings[0]], nextToken: null });
+
+    const result = await handler({ queryStringParameters: { userId: 'user-123' } });
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.data.items).toHaveLength(1);
+    expect(mockToyListing.listByUser).toHaveBeenCalledWith('user-123', 20, null);
+  });
+
+  it('should respect the limit param', async () => {
+    mockToyListing.listAll = jest.fn().mockResolvedValue({ items: [mockListings[0]], nextToken: 'token123' });
+
+    const result = await handler({ queryStringParameters: { limit: '1' } });
+
+    expect(result.statusCode).toBe(200);
+    expect(mockToyListing.listAll).toHaveBeenCalledWith(1, null);
+  });
+
+  it('should cap limit at 100', async () => {
+    mockToyListing.listAll = jest.fn().mockResolvedValue({ items: mockListings, nextToken: null });
+
+    await handler({ queryStringParameters: { limit: '999' } });
+
+    expect(mockToyListing.listAll).toHaveBeenCalledWith(100, null);
+  });
+
+  it('should return 500 when model throws', async () => {
+    mockToyListing.listAll = jest.fn().mockRejectedValue(new Error('DB fail'));
+
+    const result = await handler({ queryStringParameters: null });
+
+    expect(result.statusCode).toBe(500);
+  });
+});

--- a/bookclub-app/backend/serverless.yml
+++ b/bookclub-app/backend/serverless.yml
@@ -66,6 +66,8 @@ provider:
             - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:service}-bookclub-members-${self:provider.stage}/index/*
             - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:service}-dm-conversations-${self:provider.stage}/index/*
             - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:service}-dm-messages-${self:provider.stage}/index/*
+            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:service}-toy-listings-${self:provider.stage}
+            - arn:aws:dynamodb:${self:provider.region}:${aws:accountId}:table/${self:service}-toy-listings-${self:provider.stage}/index/*
         - Effect: Allow
           Action:
             - s3:PutObject
@@ -1061,6 +1063,83 @@ functions:
               - X-Amz-Security-Token
             allowCredentials: true
 
+  # Swap Toys marketplace functions
+  listToyListings:
+    handler: src/handlers/swaptoys/list.handler
+    events:
+      - http:
+          method: GET
+          path: /swap-toys
+          cors: true
+
+  createToyListing:
+    handler: src/handlers/swaptoys/create.handler
+    events:
+      - http:
+          method: POST
+          path: /swap-toys
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - Authorization
+              - X-Amz-Date
+              - X-Api-Key
+              - X-Amz-Security-Token
+            allowCredentials: true
+          authorizer:
+            type: COGNITO_USER_POOLS
+            authorizerId:
+              Ref: ApiGatewayAuthorizer
+
+  getToyListing:
+    handler: src/handlers/swaptoys/get.handler
+    events:
+      - http:
+          method: GET
+          path: /swap-toys/{listingId}
+          cors: true
+
+  updateToyListing:
+    handler: src/handlers/swaptoys/update.handler
+    events:
+      - http:
+          method: PUT
+          path: /swap-toys/{listingId}
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - Authorization
+              - X-Amz-Date
+              - X-Api-Key
+              - X-Amz-Security-Token
+            allowCredentials: true
+          authorizer:
+            type: COGNITO_USER_POOLS
+            authorizerId:
+              Ref: ApiGatewayAuthorizer
+
+  deleteToyListing:
+    handler: src/handlers/swaptoys/delete.handler
+    events:
+      - http:
+          method: DELETE
+          path: /swap-toys/{listingId}
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - Authorization
+              - X-Amz-Date
+              - X-Api-Key
+              - X-Amz-Security-Token
+            allowCredentials: true
+          authorizer:
+            type: COGNITO_USER_POOLS
+            authorizerId:
+              Ref: ApiGatewayAuthorizer
+
   # Interest registration (public, no auth) for upcoming features
   interestRegisterSwapToys:
     handler: src/handlers/interest/registerSwapToys.handler
@@ -1496,6 +1575,39 @@ resources:
           - IndexName: ConversationCreatedAtIndex
             KeySchema:
               - AttributeName: conversationId
+                KeyType: HASH
+              - AttributeName: createdAt
+                KeyType: RANGE
+            Projection:
+              ProjectionType: ALL
+            ProvisionedThroughput:
+              ReadCapacityUnits: 5
+              WriteCapacityUnits: 5
+        ProvisionedThroughput:
+          ReadCapacityUnits: 5
+          WriteCapacityUnits: 5
+
+    ToyListingsTable:
+      Type: AWS::CloudFormation::CustomResource
+      DeletionPolicy: Retain
+      UpdateReplacePolicy: Retain
+      Properties:
+        ServiceToken: !GetAtt DynamoTableManagerLambdaFunction.Arn
+        TableName: ${self:service}-toy-listings-${self:provider.stage}
+        AttributeDefinitions:
+          - AttributeName: listingId
+            AttributeType: S
+          - AttributeName: userId
+            AttributeType: S
+          - AttributeName: createdAt
+            AttributeType: S
+        KeySchema:
+          - AttributeName: listingId
+            KeyType: HASH
+        GlobalSecondaryIndexes:
+          - IndexName: UserIdIndex
+            KeySchema:
+              - AttributeName: userId
                 KeyType: HASH
               - AttributeName: createdAt
                 KeyType: RANGE

--- a/bookclub-app/backend/src/handlers/swaptoys/create.js
+++ b/bookclub-app/backend/src/handlers/swaptoys/create.js
@@ -1,0 +1,64 @@
+const { success, error } = require('../../lib/response');
+const ToyListing = require('../../models/toyListing');
+
+const ALLOWED_CONDITIONS = ['new', 'like_new', 'good', 'fair'];
+const ALLOWED_CATEGORIES = ['books', 'outdoor', 'educational', 'dolls', 'vehicles', 'other'];
+
+exports.handler = async (event) => {
+  try {
+    const userId =
+      event.requestContext?.authorizer?.claims?.sub ||
+      event.requestContext?.authorizer?.claims?.['cognito:username'];
+
+    if (!userId) {
+      return error('Unauthorized', 401);
+    }
+
+    let body = {};
+    try {
+      if (event.body) body = JSON.parse(event.body);
+    } catch (_) {
+      return error('Invalid JSON body', 400);
+    }
+
+    // Validate required fields
+    const validationErrors = {};
+    if (!body.title || !String(body.title).trim()) {
+      validationErrors.title = 'Title is required';
+    }
+    if (!body.condition || !ALLOWED_CONDITIONS.includes(body.condition)) {
+      validationErrors.condition = `Condition must be one of: ${ALLOWED_CONDITIONS.join(', ')}`;
+    }
+    if (body.category && !ALLOWED_CATEGORIES.includes(body.category)) {
+      validationErrors.category = `Category must be one of: ${ALLOWED_CATEGORIES.join(', ')}`;
+    }
+
+    if (Object.keys(validationErrors).length > 0) {
+      return {
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify({
+          success: false,
+          error: { code: 'VALIDATION_ERROR', message: 'Validation failed', errors: validationErrors },
+        }),
+      };
+    }
+
+    const data = {
+      title: String(body.title).trim(),
+      description: body.description ? String(body.description).trim() : '',
+      condition: body.condition,
+      category: body.category || null,
+      location: body.location ? String(body.location).trim() : null,
+      wantInReturn: body.wantInReturn ? String(body.wantInReturn).trim() : null,
+      images: Array.isArray(body.images) ? body.images : null,
+    };
+
+    const listing = await ToyListing.create(data, userId);
+    return { ...success(listing), statusCode: 201 };
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('[SwapToys][create] Error:', e);
+    return error('Failed to create toy listing', 500);
+  }
+};

--- a/bookclub-app/backend/src/handlers/swaptoys/delete.js
+++ b/bookclub-app/backend/src/handlers/swaptoys/delete.js
@@ -1,0 +1,32 @@
+const { success, error } = require('../../lib/response');
+const ToyListing = require('../../models/toyListing');
+
+exports.handler = async (event) => {
+  try {
+    const userId =
+      event.requestContext?.authorizer?.claims?.sub ||
+      event.requestContext?.authorizer?.claims?.['cognito:username'];
+
+    if (!userId) {
+      return error('Unauthorized', 401);
+    }
+
+    const listingId = event.pathParameters?.listingId;
+    if (!listingId) {
+      return error('listingId is required', 400);
+    }
+
+    await ToyListing.delete(listingId, userId);
+    return success({ deleted: true });
+  } catch (e) {
+    if (e.message && (e.message.includes('permission') || e.message.includes('authorised'))) {
+      return error(e.message, 403);
+    }
+    if (e.message && e.message.includes('not found')) {
+      return error(e.message, 404);
+    }
+    // eslint-disable-next-line no-console
+    console.error('[SwapToys][delete] Error:', e);
+    return error('Failed to delete toy listing', 500);
+  }
+};

--- a/bookclub-app/backend/src/handlers/swaptoys/get.js
+++ b/bookclub-app/backend/src/handlers/swaptoys/get.js
@@ -1,0 +1,22 @@
+const { success, error } = require('../../lib/response');
+const ToyListing = require('../../models/toyListing');
+
+exports.handler = async (event) => {
+  try {
+    const listingId = event.pathParameters?.listingId;
+    if (!listingId) {
+      return error('listingId is required', 400);
+    }
+
+    const listing = await ToyListing.getById(listingId);
+    if (!listing) {
+      return error('Listing not found', 404);
+    }
+
+    return success(listing);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('[SwapToys][get] Error:', e);
+    return error('Failed to get toy listing', 500);
+  }
+};

--- a/bookclub-app/backend/src/handlers/swaptoys/list.js
+++ b/bookclub-app/backend/src/handlers/swaptoys/list.js
@@ -1,0 +1,23 @@
+const { success, error } = require('../../lib/response');
+const ToyListing = require('../../models/toyListing');
+
+exports.handler = async (event) => {
+  try {
+    const limit = Math.min(parseInt(event.queryStringParameters?.limit || '20', 10), 100);
+    const nextToken = event.queryStringParameters?.nextToken || null;
+    const userId = event.queryStringParameters?.userId || null;
+
+    let result;
+    if (userId) {
+      result = await ToyListing.listByUser(userId, limit, nextToken);
+    } else {
+      result = await ToyListing.listAll(limit, nextToken);
+    }
+
+    return success(result);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('[SwapToys][list] Error:', e);
+    return error('Failed to list toy listings', 500);
+  }
+};

--- a/bookclub-app/backend/src/handlers/swaptoys/update.js
+++ b/bookclub-app/backend/src/handlers/swaptoys/update.js
@@ -1,0 +1,75 @@
+const { success, error } = require('../../lib/response');
+const ToyListing = require('../../models/toyListing');
+
+const ALLOWED_CONDITIONS = ['new', 'like_new', 'good', 'fair'];
+const ALLOWED_CATEGORIES = ['books', 'outdoor', 'educational', 'dolls', 'vehicles', 'other'];
+const ALLOWED_STATUSES = ['available', 'swapped'];
+const ALLOWED_FIELDS = ['title', 'description', 'condition', 'category', 'images', 'status', 'location', 'wantInReturn'];
+
+exports.handler = async (event) => {
+  try {
+    const userId =
+      event.requestContext?.authorizer?.claims?.sub ||
+      event.requestContext?.authorizer?.claims?.['cognito:username'];
+
+    if (!userId) {
+      return error('Unauthorized', 401);
+    }
+
+    const listingId = event.pathParameters?.listingId;
+    if (!listingId) {
+      return error('listingId is required', 400);
+    }
+
+    let body = {};
+    try {
+      if (event.body) body = JSON.parse(event.body);
+    } catch (_) {
+      return error('Invalid JSON body', 400);
+    }
+
+    // Validate updatable fields
+    const validationErrors = {};
+    if (body.condition !== undefined && !ALLOWED_CONDITIONS.includes(body.condition)) {
+      validationErrors.condition = `Condition must be one of: ${ALLOWED_CONDITIONS.join(', ')}`;
+    }
+    if (body.category !== undefined && body.category !== null && !ALLOWED_CATEGORIES.includes(body.category)) {
+      validationErrors.category = `Category must be one of: ${ALLOWED_CATEGORIES.join(', ')}`;
+    }
+    if (body.status !== undefined && !ALLOWED_STATUSES.includes(body.status)) {
+      validationErrors.status = `Status must be one of: ${ALLOWED_STATUSES.join(', ')}`;
+    }
+
+    if (Object.keys(validationErrors).length > 0) {
+      return {
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify({
+          success: false,
+          error: { code: 'VALIDATION_ERROR', message: 'Validation failed', errors: validationErrors },
+        }),
+      };
+    }
+
+    // Only permit known fields
+    const updates = {};
+    for (const field of ALLOWED_FIELDS) {
+      if (body[field] !== undefined) {
+        updates[field] = body[field];
+      }
+    }
+
+    const updated = await ToyListing.update(listingId, userId, updates);
+    return success(updated);
+  } catch (e) {
+    if (e.message && (e.message.includes('permission') || e.message.includes('authorised'))) {
+      return error(e.message, 403);
+    }
+    if (e.message && e.message.includes('not found')) {
+      return error(e.message, 404);
+    }
+    // eslint-disable-next-line no-console
+    console.error('[SwapToys][update] Error:', e);
+    return error('Failed to update toy listing', 500);
+  }
+};

--- a/bookclub-app/backend/src/lib/local-storage.js
+++ b/bookclub-app/backend/src/lib/local-storage.js
@@ -13,6 +13,7 @@ const USERS_FILE = path.join(STORAGE_DIR, 'users.json');
 const BOOKS_FILE = path.join(STORAGE_DIR, 'books.json');
 const CLUBS_FILE = path.join(STORAGE_DIR, 'clubs.json');
 const CLUB_MEMBERS_FILE = path.join(STORAGE_DIR, 'club-members.json');
+const TOY_LISTINGS_FILE = path.join(STORAGE_DIR, 'toy-listings.json');
 
 if (OFFLINE) {
   // Ensure storage directory exists (local only)
@@ -337,6 +338,76 @@ class LocalStorage {
       }
     }
     this.saveClubMembers(filtered);
+  }
+
+  // Toy listing operations
+  static loadToyListings() {
+    if (!OFFLINE) return {};
+    try {
+      if (fs.existsSync(TOY_LISTINGS_FILE)) {
+        return JSON.parse(fs.readFileSync(TOY_LISTINGS_FILE, 'utf8'));
+      }
+    } catch (error) {
+      console.error('[LocalStorage] Error loading toy listings:', error);
+    }
+    return {};
+  }
+
+  static saveToyListings(listings) {
+    if (!OFFLINE) return;
+    try {
+      fs.writeFileSync(TOY_LISTINGS_FILE, JSON.stringify(listings, null, 2));
+    } catch (error) {
+      console.error('[LocalStorage] Error saving toy listings:', error);
+    }
+  }
+
+  static async createToyListing(listing) {
+    if (!OFFLINE) return listing;
+    const listings = this.loadToyListings();
+    listings[listing.listingId] = listing;
+    this.saveToyListings(listings);
+    return listing;
+  }
+
+  static async getToyListing(listingId) {
+    if (!OFFLINE) return null;
+    const listings = this.loadToyListings();
+    return listings[listingId] || null;
+  }
+
+  static async listToyListings(userId = null) {
+    if (!OFFLINE) return [];
+    const listings = this.loadToyListings();
+    const all = Object.values(listings);
+    if (userId) {
+      return all.filter((l) => l.userId === userId);
+    }
+    return all;
+  }
+
+  static async updateToyListing(listingId, updates) {
+    if (!OFFLINE) return null;
+    const listings = this.loadToyListings();
+    const listing = listings[listingId];
+    if (listing) {
+      const updated = { ...listing, ...updates, updatedAt: new Date().toISOString() };
+      listings[listingId] = updated;
+      this.saveToyListings(listings);
+      return updated;
+    }
+    return null;
+  }
+
+  static async deleteToyListing(listingId) {
+    if (!OFFLINE) return false;
+    const listings = this.loadToyListings();
+    if (listings[listingId]) {
+      delete listings[listingId];
+      this.saveToyListings(listings);
+      return true;
+    }
+    return false;
   }
 }
 

--- a/bookclub-app/backend/src/lib/table-names.js
+++ b/bookclub-app/backend/src/lib/table-names.js
@@ -9,6 +9,7 @@ const tableNames = {
   'bookclub-members': `${SERVICE_NAME}-bookclub-members-${STAGE}`,
   'dm-conversations': `${SERVICE_NAME}-dm-conversations-${STAGE}`,
   'dm-messages': `${SERVICE_NAME}-dm-messages-${STAGE}`,
+  'toy-listings': `${SERVICE_NAME}-toy-listings-${STAGE}`,
 };
 
 function getTableName(key) {

--- a/bookclub-app/backend/src/models/toyListing.js
+++ b/bookclub-app/backend/src/models/toyListing.js
@@ -1,0 +1,205 @@
+const { v4: uuidv4 } = require('uuid');
+const { getTableName } = require('../lib/table-names');
+const dynamoDb = require('../lib/dynamodb');
+
+const isOffline = () =>
+  process.env.IS_OFFLINE === 'true' || process.env.NODE_ENV === 'development';
+
+// Lazy loader to avoid requiring local-storage in AWS Lambda
+let _LocalStorage = null;
+function LocalStorage() {
+  if (!_LocalStorage) {
+    // eslint-disable-next-line global-require
+    _LocalStorage = require('../lib/local-storage');
+  }
+  return _LocalStorage;
+}
+
+class ToyListing {
+  /**
+   * Create a new toy listing.
+   * @param {Object} data
+   * @param {string} userId - The authenticated user's ID.
+   */
+  static async create(data, userId) {
+    const listingId = uuidv4();
+    const timestamp = new Date().toISOString();
+
+    const listing = {
+      listingId,
+      userId,
+      title: data.title,
+      description: data.description || '',
+      condition: data.condition || 'good', // new | like_new | good | fair
+      category: data.category || null,
+      images: data.images || null,
+      status: 'available',
+      location: data.location || null,
+      wantInReturn: data.wantInReturn || null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    if (isOffline()) {
+      await LocalStorage().createToyListing(listing);
+      return listing;
+    }
+
+    await dynamoDb.put(getTableName('toy-listings'), listing);
+    return listing;
+  }
+
+  /**
+   * Get a single listing by ID.
+   */
+  static async getById(listingId) {
+    if (isOffline()) {
+      return LocalStorage().getToyListing(listingId);
+    }
+    return dynamoDb.get(getTableName('toy-listings'), { listingId });
+  }
+
+  /**
+   * List all listings (public browse), with optional search and pagination.
+   */
+  static async listAll(limit = 20, nextToken = null) {
+    if (isOffline()) {
+      const all = await LocalStorage().listToyListings();
+      return {
+        items: all.slice(0, limit),
+        nextToken: all.length > limit ? 'has-more' : null,
+      };
+    }
+
+    const params = {
+      TableName: getTableName('toy-listings'),
+      Limit: limit,
+    };
+
+    if (nextToken) {
+      params.ExclusiveStartKey = JSON.parse(
+        Buffer.from(nextToken, 'base64').toString('utf-8')
+      );
+    }
+
+    const result = await dynamoDb.scan(params);
+    return {
+      items: result.Items || [],
+      nextToken: result.LastEvaluatedKey
+        ? Buffer.from(JSON.stringify(result.LastEvaluatedKey)).toString('base64')
+        : null,
+    };
+  }
+
+  /**
+   * List listings for a specific user (via GSI UserIdIndex).
+   */
+  static async listByUser(userId, limit = 50, nextToken = null) {
+    if (isOffline()) {
+      const all = await LocalStorage().listToyListings(userId);
+      return {
+        items: all.slice(0, limit),
+        nextToken: all.length > limit ? 'has-more' : null,
+      };
+    }
+
+    const params = {
+      TableName: getTableName('toy-listings'),
+      IndexName: 'UserIdIndex',
+      KeyConditionExpression: 'userId = :userId',
+      ExpressionAttributeValues: {
+        ':userId': userId,
+      },
+      Limit: limit,
+      ScanIndexForward: false,
+    };
+
+    if (nextToken) {
+      params.ExclusiveStartKey = JSON.parse(
+        Buffer.from(nextToken, 'base64').toString('utf-8')
+      );
+    }
+
+    const result = await dynamoDb.query(params);
+    return {
+      items: result.Items || [],
+      nextToken: result.LastEvaluatedKey
+        ? Buffer.from(JSON.stringify(result.LastEvaluatedKey)).toString('base64')
+        : null,
+    };
+  }
+
+  /**
+   * Update a listing. Only the owner can update (ConditionExpression).
+   */
+  static async update(listingId, userId, updates) {
+    const timestamp = new Date().toISOString();
+    const updateData = { ...updates, updatedAt: timestamp };
+
+    if (isOffline()) {
+      // Verify ownership in offline mode
+      const existing = await LocalStorage().getToyListing(listingId);
+      if (!existing) throw new Error('Listing not found');
+      if (existing.userId !== userId) throw new Error('Not authorised');
+      return LocalStorage().updateToyListing(listingId, updateData);
+    }
+
+    const { UpdateExpression, ExpressionAttributeNames, ExpressionAttributeValues } =
+      dynamoDb.generateUpdateExpression(updateData);
+
+    const params = {
+      TableName: getTableName('toy-listings'),
+      Key: { listingId },
+      UpdateExpression,
+      ExpressionAttributeNames,
+      ExpressionAttributeValues,
+      ConditionExpression: 'userId = :userId',
+      ReturnValues: 'ALL_NEW',
+    };
+
+    ExpressionAttributeValues[':userId'] = userId;
+
+    try {
+      const result = await dynamoDb.update(params);
+      return result.Attributes;
+    } catch (err) {
+      if (err.code === 'ConditionalCheckFailedException') {
+        throw new Error('Listing not found or you do not have permission to update it');
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Delete a listing. Only the owner can delete.
+   */
+  static async delete(listingId, userId) {
+    if (isOffline()) {
+      const existing = await LocalStorage().getToyListing(listingId);
+      if (!existing) throw new Error('Listing not found');
+      if (existing.userId !== userId) throw new Error('Not authorised');
+      return LocalStorage().deleteToyListing(listingId);
+    }
+
+    const params = {
+      TableName: getTableName('toy-listings'),
+      Key: { listingId },
+      ConditionExpression: 'userId = :userId',
+      ExpressionAttributeValues: {
+        ':userId': userId,
+      },
+    };
+
+    try {
+      await dynamoDb.delete(params);
+      return { success: true };
+    } catch (err) {
+      if (err.code === 'ConditionalCheckFailedException') {
+        throw new Error('Listing not found or you do not have permission to delete it');
+      }
+      throw err;
+    }
+  }
+}
+
+module.exports = ToyListing;

--- a/bookclub-app/frontend/src/components/CreateToyListingModal.tsx
+++ b/bookclub-app/frontend/src/components/CreateToyListingModal.tsx
@@ -1,0 +1,217 @@
+import React, { useState } from 'react';
+import { apiService } from '../services/api';
+import { ToyListing } from '../types';
+
+const CONDITIONS = [
+  { value: 'new', label: 'New' },
+  { value: 'like_new', label: 'Like New' },
+  { value: 'good', label: 'Good' },
+  { value: 'fair', label: 'Fair' },
+];
+
+const CATEGORIES = [
+  { value: '', label: 'None' },
+  { value: 'books', label: '📚 Books' },
+  { value: 'outdoor', label: '🌳 Outdoor' },
+  { value: 'educational', label: '🎓 Educational' },
+  { value: 'dolls', label: '🧸 Dolls' },
+  { value: 'vehicles', label: '🚗 Vehicles' },
+  { value: 'other', label: '🎁 Other' },
+];
+
+interface Props {
+  onClose: () => void;
+  onCreated: (listing: ToyListing) => void;
+}
+
+const CreateToyListingModal: React.FC<Props> = ({ onClose, onCreated }) => {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [condition, setCondition] = useState('good');
+  const [category, setCategory] = useState('');
+  const [location, setLocation] = useState('');
+  const [wantInReturn, setWantInReturn] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [serverError, setServerError] = useState('');
+
+  const validate = () => {
+    const e: Record<string, string> = {};
+    if (!title.trim()) e.title = 'Title is required';
+    if (!condition) e.condition = 'Condition is required';
+    return e;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const errs = validate();
+    if (Object.keys(errs).length > 0) {
+      setErrors(errs);
+      return;
+    }
+    setErrors({});
+    setServerError('');
+    setIsSubmitting(true);
+    try {
+      const listing = await apiService.createToyListing({
+        title: title.trim(),
+        description: description.trim() || undefined,
+        condition,
+        category: category || undefined,
+        location: location.trim() || undefined,
+        wantInReturn: wantInReturn.trim() || undefined,
+      });
+      onCreated(listing);
+    } catch (err: any) {
+      setServerError(err?.message || 'Failed to create listing. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Close when clicking backdrop
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const inputClass = (field: string) =>
+    `mt-1 block w-full rounded-lg border ${errors[field] ? 'border-red-400 bg-red-50' : 'border-gray-300'} px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ backgroundColor: 'rgba(0,0,0,0.45)' }}
+      onClick={handleBackdropClick}
+    >
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+          <h2 className="text-lg font-semibold text-gray-900">Post a Toy</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
+          {/* Title */}
+          <div>
+            <label htmlFor="ct-title" className="block text-sm font-medium text-gray-700">
+              Title <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="ct-title"
+              type="text"
+              value={title}
+              onChange={(e) => { setTitle(e.target.value); setErrors((p) => { const n = {...p}; delete n.title; return n; }); }}
+              placeholder="e.g. Wooden train set, 50 pieces"
+              className={inputClass('title')}
+            />
+            {errors.title && <p className="mt-1 text-xs text-red-600">{errors.title}</p>}
+          </div>
+
+          {/* Description */}
+          <div>
+            <label htmlFor="ct-description" className="block text-sm font-medium text-gray-700">Description</label>
+            <textarea
+              id="ct-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              placeholder="Describe the toy, any missing pieces, age range, etc."
+              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent resize-none"
+            />
+          </div>
+
+          {/* Condition + Category */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="ct-condition" className="block text-sm font-medium text-gray-700">
+                Condition <span className="text-red-500">*</span>
+              </label>
+              <select
+                id="ct-condition"
+                value={condition}
+                onChange={(e) => { setCondition(e.target.value); setErrors((p) => { const n = {...p}; delete n.condition; return n; }); }}
+                className={inputClass('condition')}
+              >
+                {CONDITIONS.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
+                ))}
+              </select>
+              {errors.condition && <p className="mt-1 text-xs text-red-600">{errors.condition}</p>}
+            </div>
+            <div>
+              <label htmlFor="ct-category" className="block text-sm font-medium text-gray-700">Category</label>
+              <select
+                id="ct-category"
+                value={category}
+                onChange={(e) => setCategory(e.target.value)}
+                className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+              >
+                {CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Location */}
+          <div>
+            <label htmlFor="ct-location" className="block text-sm font-medium text-gray-700">Location</label>
+            <input
+              id="ct-location"
+              type="text"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="e.g. Melbourne, VIC"
+              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            />
+          </div>
+
+          {/* Want in return */}
+          <div>
+            <label htmlFor="ct-want" className="block text-sm font-medium text-gray-700">Looking for in return</label>
+            <input
+              id="ct-want"
+              type="text"
+              value={wantInReturn}
+              onChange={(e) => setWantInReturn(e.target.value)}
+              placeholder="e.g. LEGO sets, board games, books"
+              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            />
+          </div>
+
+          {serverError && (
+            <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+              {serverError}
+            </div>
+          )}
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-2.5 rounded-lg border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="flex-1 px-4 py-2.5 rounded-lg bg-indigo-600 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-60 transition-colors"
+            >
+              {isSubmitting ? 'Posting…' : 'Post Toy'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default CreateToyListingModal;

--- a/bookclub-app/frontend/src/components/ToyListingCard.tsx
+++ b/bookclub-app/frontend/src/components/ToyListingCard.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { ToyListing } from '../types';
+
+const CONDITION_LABELS: Record<string, { label: string; color: string }> = {
+  new: { label: 'New', color: 'bg-green-100 text-green-800' },
+  like_new: { label: 'Like New', color: 'bg-teal-100 text-teal-800' },
+  good: { label: 'Good', color: 'bg-blue-100 text-blue-800' },
+  fair: { label: 'Fair', color: 'bg-yellow-100 text-yellow-800' },
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  books: '📚 Books',
+  outdoor: '🌳 Outdoor',
+  educational: '🎓 Educational',
+  dolls: '🧸 Dolls',
+  vehicles: '🚗 Vehicles',
+  other: '🎁 Other',
+};
+
+interface ToyListingCardProps {
+  listing: ToyListing;
+  onDelete?: (listingId: string) => void;
+  isDeleting?: boolean;
+}
+
+const ToyListingCard: React.FC<ToyListingCardProps> = ({ listing, onDelete, isDeleting }) => {
+  const condition = CONDITION_LABELS[listing.condition] ?? { label: listing.condition, color: 'bg-gray-100 text-gray-700' };
+  const category = listing.category ? CATEGORY_LABELS[listing.category] ?? listing.category : null;
+
+  const timeAgo = (iso: string) => {
+    const diff = Date.now() - new Date(iso).getTime();
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+    if (days === 0) return 'Today';
+    if (days === 1) return 'Yesterday';
+    if (days < 7) return `${days} days ago`;
+    const weeks = Math.floor(days / 7);
+    if (weeks < 5) return `${weeks}w ago`;
+    return new Date(iso).toLocaleDateString();
+  };
+
+  return (
+    <div className="relative bg-white rounded-2xl shadow-sm border border-gray-100 hover:shadow-md transition-shadow duration-200 flex flex-col">
+      {/* Status badge */}
+      {listing.status === 'swapped' && (
+        <div className="absolute top-3 right-3 bg-gray-200 text-gray-600 text-xs font-semibold px-2 py-0.5 rounded-full">
+          Swapped
+        </div>
+      )}
+
+      <div className="p-5 flex flex-col flex-1">
+        {/* Header */}
+        <div className="flex items-start gap-2 mb-3">
+          <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${condition.color}`}>
+            {condition.label}
+          </span>
+          {category && (
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700">
+              {category}
+            </span>
+          )}
+        </div>
+
+        {/* Title */}
+        <h3 className="text-base font-semibold text-gray-900 mb-1 line-clamp-2">{listing.title}</h3>
+
+        {/* Description */}
+        {listing.description && (
+          <p className="text-sm text-gray-600 mb-3 line-clamp-2">{listing.description}</p>
+        )}
+
+        {/* Want in return */}
+        {listing.wantInReturn && (
+          <p className="text-sm text-indigo-700 bg-indigo-50 rounded-lg px-3 py-2 mb-3">
+            <span className="font-medium">Looking for:</span> {listing.wantInReturn}
+          </p>
+        )}
+
+        <div className="mt-auto pt-3 border-t border-gray-50 flex items-center justify-between text-xs text-gray-500">
+          <div className="flex flex-col gap-0.5">
+            {listing.userName && <span className="font-medium text-gray-700">{listing.userName}</span>}
+            {listing.location && <span>📍 {listing.location}</span>}
+            <span>{timeAgo(listing.createdAt)}</span>
+          </div>
+          {onDelete && (
+            <button
+              onClick={() => onDelete(listing.listingId)}
+              disabled={isDeleting}
+              aria-label="Delete listing"
+              className="ml-3 flex-shrink-0 text-red-500 hover:text-red-700 disabled:opacity-50 transition-colors"
+            >
+              {isDeleting ? (
+                <svg className="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+              ) : (
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ToyListingCard;

--- a/bookclub-app/frontend/src/pages/SwapToys.tsx
+++ b/bookclub-app/frontend/src/pages/SwapToys.tsx
@@ -1,164 +1,242 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { apiService } from '../services/api';
+import { ToyListing } from '../types';
+import { useAuth } from '../contexts/AuthContext';
+import ToyListingCard from '../components/ToyListingCard';
+import CreateToyListingModal from '../components/CreateToyListingModal';
+
+type TabId = 'browse' | 'mine';
+
+const EMPTY_BROWSE = (
+  <div className="col-span-full flex flex-col items-center justify-center py-20 text-center text-gray-500">
+    <span className="text-5xl mb-4">🧸</span>
+    <p className="text-lg font-medium text-gray-700">No toys listed yet</p>
+    <p className="text-sm mt-1">Be the first to post a toy and start swapping!</p>
+  </div>
+);
+
+const EMPTY_MINE = (
+  <div className="col-span-full flex flex-col items-center justify-center py-20 text-center text-gray-500">
+    <span className="text-5xl mb-4">🎁</span>
+    <p className="text-lg font-medium text-gray-700">You haven't posted any toys yet</p>
+    <p className="text-sm mt-1">Click <strong>"Post a Toy"</strong> to list a toy you'd like to swap.</p>
+  </div>
+);
 
 const SwapToys: React.FC = () => {
-  const [status, setStatus] = useState<'idle' | 'success' | 'error' | 'loading'>('idle');
-  const [message, setMessage] = useState<string>('');
-  const [email, setEmail] = useState<string>('');
-  const [emailError, setEmailError] = useState<string>('');
+  const { isAuthenticated, user } = useAuth();
+  const navigate = useNavigate();
 
-  const handleRegisterInterest = async () => {
-    try {
-      setStatus('loading');
-      setMessage('');
-      const trimmed = email.trim();
-      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-      if (!trimmed || !emailRegex.test(trimmed)) {
-        setStatus('error');
-        setEmailError('Please enter a valid email address');
-        setMessage('');
-        return;
-      }
+  const [tab, setTab] = useState<TabId>('browse');
+  const [listings, setListings] = useState<ToyListing[]>([]);
+  const [myListings, setMyListings] = useState<ToyListing[]>([]);
+  const [nextToken, setNextToken] = useState<string | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState('');
+  const [showModal, setShowModal] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
-      await apiService.request<any>('/interest/swap-toys', {
-        method: 'POST',
-        body: JSON.stringify({ from: window.location.href, email: trimmed }),
-      });
-      setStatus('success');
-      setMessage('Thanks! Your interest is registered. We\'ll notify you when it\'s ready.');
-      setEmail('');
-      setEmailError('');
-    } catch (e: any) {
-      setStatus('error');
-      setMessage(e?.message || 'Failed to register your interest. Please try again.');
-    }
-  };
-
-  const shareUrl = (typeof window !== 'undefined' ? window.location.origin : '') + '/swap-toys';
-  const shareText = "Help unlock Swap Toys on BookClub! If we reach 100 interested users, we'll launch it.";
-
-  // SEO: title/description + JSON-LD Event
-  React.useEffect(() => {
+  // SEO
+  useEffect(() => {
     document.title = 'Swap Toys — BookClub';
-    const desc = "Register your interest in Swap Toys. If we reach 100 users, we'll make it live!";
     let metaDesc = document.querySelector('meta[name="description"]');
     if (!metaDesc) {
       metaDesc = document.createElement('meta');
       metaDesc.setAttribute('name', 'description');
       document.head.appendChild(metaDesc);
     }
-    metaDesc.setAttribute('content', desc);
+    metaDesc.setAttribute('content', 'Browse and swap toys with families in your local community. Post a toy you no longer need and find a new favourite.');
+  }, []);
 
-    const ld: any = {
-      '@context': 'https://schema.org',
-      '@type': 'Event',
-      name: 'Swap Toys Interest Drive',
-      description: desc,
-      startDate: new Date().toISOString(),
-      url: shareUrl,
-      eventStatus: 'https://schema.org/EventScheduled',
-      organizer: { '@type': 'Organization', name: 'BookClub' },
-    };
-    const script = document.createElement('script');
-    script.type = 'application/ld+json';
-    script.setAttribute('data-seo', 'event-jsonld');
-    script.text = JSON.stringify(ld);
-    document.querySelectorAll('script[data-seo="event-jsonld"]').forEach(n => n.remove());
-    document.head.appendChild(script);
-    return () => {
-      document.querySelectorAll('script[data-seo="event-jsonld"]').forEach(n => n.remove());
-    };
-  }, [shareUrl]);
-
-  const handleShare = async () => {
+  // Load all listings
+  const loadListings = useCallback(async (token?: string) => {
     try {
-      if (navigator.share) {
-        await navigator.share({ title: 'Swap Toys — BookClub', text: shareText, url: shareUrl });
-      } else {
-        await navigator.clipboard.writeText(`${shareText} ${shareUrl}`);
-        setMessage('Share text copied to clipboard!');
-      }
-    } catch (_) {
-      // ignore user cancel
+      if (!token) setIsLoading(true); else setIsLoadingMore(true);
+      setError('');
+      const res = await apiService.listToyListings({ limit: 24, nextToken: token });
+      setListings((prev) => token ? [...prev, ...res.items] : res.items);
+      setNextToken(res.nextToken);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load listings. Please try again.');
+    } finally {
+      setIsLoading(false);
+      setIsLoadingMore(false);
+    }
+  }, []);
+
+  // Load user's own listings
+  const loadMyListings = useCallback(async () => {
+    if (!user?.userId) return;
+    try {
+      setIsLoading(true);
+      setError('');
+      const res = await apiService.listToyListings({ userId: user.userId, limit: 50 });
+      setMyListings(res.items);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load your listings.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [user?.userId]);
+
+  useEffect(() => {
+    if (tab === 'browse') {
+      loadListings();
+    } else if (tab === 'mine') {
+      loadMyListings();
+    }
+  }, [tab, loadListings, loadMyListings]);
+
+  const handleCreated = (listing: ToyListing) => {
+    setShowModal(false);
+    setListings((prev) => [listing, ...prev]);
+    setMyListings((prev) => [listing, ...prev]);
+  };
+
+  const handleDelete = async (listingId: string) => {
+    if (!window.confirm('Are you sure you want to delete this listing?')) return;
+    setDeletingId(listingId);
+    try {
+      await apiService.deleteToyListing(listingId);
+      setMyListings((prev) => prev.filter((l) => l.listingId !== listingId));
+      setListings((prev) => prev.filter((l) => l.listingId !== listingId));
+    } catch (e: any) {
+      setError(e?.message || 'Failed to delete listing.');
+    } finally {
+      setDeletingId(null);
     }
   };
 
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(`${shareText} ${shareUrl}`);
-      setMessage('Link copied to clipboard!');
-      setStatus('success');
-    } catch (e) {
-      setStatus('error');
-      setMessage('Could not copy link.');
-    }
-  };
+  const activeListings = tab === 'browse' ? listings : myListings;
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <div className="max-w-3xl mx-auto px-4 py-10">
-        <h1 className="text-3xl font-bold text-gray-900">Swap Toys (Coming soon)</h1>
-        <p className="mt-3 text-gray-700">
-          Register your interest in Swap Toys. If we reach 100 users, we'll make it live!
-        </p>
-
-        <div className="mt-6 flex items-end gap-3">
-          <div className="flex-1 min-w-0">
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700">Email address</label>
-            <input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => { setEmail(e.target.value); setEmailError(''); }}
-              placeholder="you@example.com"
-              className={`mt-1 block w-full rounded-md border ${emailError ? 'border-red-300' : 'border-gray-300'} px-3 py-2 shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500`}
-            />
-            {emailError && <p className="mt-1 text-sm text-red-600">{emailError}</p>}
-            <p className="mt-1 text-xs text-gray-500">We\'ll only use this to notify you when Swap Toys is ready.</p>
+      {/* Hero */}
+      <div className="bg-white border-b border-gray-100 py-8 px-4">
+        <div className="max-w-5xl mx-auto flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">🧸 Swap Toys</h1>
+            <p className="mt-1 text-gray-600 text-sm">
+              Give toys a second life — swap with families in your community.
+            </p>
           </div>
-          <button
-            onClick={handleRegisterInterest}
-            disabled={status === 'loading'}
-            className="h-11 inline-flex items-center justify-center px-5 py-3 rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-60 whitespace-nowrap"
-          >
-            {status === 'loading' ? 'Registering…' : 'Register Interest'}
-          </button>
+          {isAuthenticated ? (
+            <button
+              id="post-toy-btn"
+              onClick={() => setShowModal(true)}
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-indigo-600 text-white text-sm font-semibold hover:bg-indigo-700 transition-colors shadow-sm"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+              </svg>
+              Post a Toy
+            </button>
+          ) : (
+            <button
+              onClick={() => navigate('/login')}
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-indigo-300 text-indigo-700 text-sm font-semibold hover:bg-indigo-50 transition-colors"
+            >
+              Sign in to post
+            </button>
+          )}
         </div>
-        <div className="mt-3 flex items-center gap-3">
-          <button
-            onClick={handleShare}
-            className="inline-flex items-center justify-center px-5 py-2.5 rounded-md border border-gray-300 bg-white text-gray-800 hover:bg-gray-50"
-          >
-            Share this link
-          </button>
-          <button
-            onClick={handleCopy}
-            className="inline-flex items-center justify-center px-5 py-2.5 rounded-md border border-gray-300 bg-white text-gray-800 hover:bg-gray-50"
-          >
-            Copy link
-          </button>
-        </div>
+      </div>
 
-        {message && (
-          <div className={`mt-4 rounded-md p-4 ${status === 'error' ? 'bg-red-50 text-red-700' : 'bg-green-50 text-green-800'}`}>
-            {message}
+      {/* Tabs */}
+      <div className="max-w-5xl mx-auto px-4 pt-6">
+        <div className="flex gap-1 bg-gray-100 rounded-xl p-1 w-fit">
+          <button
+            id="tab-browse"
+            onClick={() => setTab('browse')}
+            className={`px-5 py-2 rounded-lg text-sm font-medium transition-colors ${
+              tab === 'browse'
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            Browse All
+          </button>
+          {isAuthenticated && (
+            <button
+              id="tab-mine"
+              onClick={() => setTab('mine')}
+              className={`px-5 py-2 rounded-lg text-sm font-medium transition-colors ${
+                tab === 'mine'
+                  ? 'bg-white text-gray-900 shadow-sm'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              My Listings
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-5xl mx-auto px-4 py-6">
+        {/* Error */}
+        {error && (
+          <div className="mb-6 rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700 flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            {error}
           </div>
         )}
 
-        <div className="mt-8">
-          <h2 className="text-lg font-semibold text-gray-900">Why Swap Toys?</h2>
-          <ul className="mt-3 list-disc list-inside text-gray-700 space-y-1">
-            <li>Give toys a second life and reduce waste</li>
-            <li>Save money and discover new favourites</li>
-            <li>Swap safely within your local community</li>
-          </ul>
-        </div>
+        {/* Loading skeleton */}
+        {isLoading && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5 animate-pulse">
+                <div className="h-4 bg-gray-200 rounded w-1/3 mb-3" />
+                <div className="h-5 bg-gray-200 rounded w-4/5 mb-2" />
+                <div className="h-4 bg-gray-200 rounded w-full mb-1" />
+                <div className="h-4 bg-gray-200 rounded w-3/4" />
+              </div>
+            ))}
+          </div>
+        )}
 
-        <div className="mt-8">
-          <p className="text-gray-700">Share this with your friends:</p>
-          <code className="block mt-2 bg-gray-100 border border-gray-200 rounded px-3 py-2 text-sm text-gray-800 break-all">{shareUrl}</code>
-        </div>
+        {/* Listings grid */}
+        {!isLoading && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {activeListings.length === 0
+              ? (tab === 'browse' ? EMPTY_BROWSE : EMPTY_MINE)
+              : activeListings.map((listing) => (
+                  <ToyListingCard
+                    key={listing.listingId}
+                    listing={listing}
+                    onDelete={tab === 'mine' ? handleDelete : undefined}
+                    isDeleting={deletingId === listing.listingId}
+                  />
+                ))}
+          </div>
+        )}
+
+        {/* Load more */}
+        {!isLoading && tab === 'browse' && nextToken && (
+          <div className="mt-8 flex justify-center">
+            <button
+              onClick={() => loadListings(nextToken)}
+              disabled={isLoadingMore}
+              className="px-6 py-2.5 rounded-xl border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-50 transition-colors"
+            >
+              {isLoadingMore ? 'Loading…' : 'Load more'}
+            </button>
+          </div>
+        )}
       </div>
+
+      {/* Create modal */}
+      {showModal && (
+        <CreateToyListingModal
+          onClose={() => setShowModal(false)}
+          onCreated={handleCreated}
+        />
+      )}
     </div>
   );
 };

--- a/bookclub-app/frontend/src/services/api.ts
+++ b/bookclub-app/frontend/src/services/api.ts
@@ -570,6 +570,57 @@ class ApiService {
     
     return response.data as T;
   }
+
+  // Swap Toys methods
+  async listToyListings(params?: {
+    limit?: number;
+    nextToken?: string;
+    userId?: string;
+  }): Promise<import('../types').ToyListingListResponse> {
+    const query = new URLSearchParams();
+    if (params?.limit) query.append('limit', String(params.limit));
+    if (params?.nextToken) query.append('nextToken', params.nextToken);
+    if (params?.userId) query.append('userId', params.userId);
+    const response = await this.api.get(`/swap-toys?${query.toString()}`);
+    if (response.data?.success !== undefined) {
+      if (!response.data.success) throw new Error(response.data.error?.message || 'Failed to list toy listings');
+      return response.data.data as import('../types').ToyListingListResponse;
+    }
+    return response.data as import('../types').ToyListingListResponse;
+  }
+
+  async createToyListing(data: {
+    title: string;
+    description?: string;
+    condition: string;
+    category?: string;
+    location?: string;
+    wantInReturn?: string;
+  }): Promise<import('../types').ToyListing> {
+    const response = await this.api.post('/swap-toys', data);
+    if (!response.data.success) throw new Error(response.data.error?.message || 'Failed to create toy listing');
+    return response.data.data as import('../types').ToyListing;
+  }
+
+  async getToyListing(listingId: string): Promise<import('../types').ToyListing> {
+    const response = await this.api.get(`/swap-toys/${listingId}`);
+    if (!response.data.success) throw new Error(response.data.error?.message || 'Failed to get toy listing');
+    return response.data.data as import('../types').ToyListing;
+  }
+
+  async updateToyListing(
+    listingId: string,
+    updates: Partial<import('../types').ToyListing>
+  ): Promise<import('../types').ToyListing> {
+    const response = await this.api.put(`/swap-toys/${listingId}`, updates);
+    if (!response.data.success) throw new Error(response.data.error?.message || 'Failed to update toy listing');
+    return response.data.data as import('../types').ToyListing;
+  }
+
+  async deleteToyListing(listingId: string): Promise<void> {
+    const response = await this.api.delete(`/swap-toys/${listingId}`);
+    if (!response.data.success) throw new Error(response.data.error?.message || 'Failed to delete toy listing');
+  }
 }
 
 export const apiService = new ApiService();

--- a/bookclub-app/frontend/src/types/index.ts
+++ b/bookclub-app/frontend/src/types/index.ts
@@ -176,3 +176,27 @@ export interface DMMessageList {
   items: DMMessage[];
   nextToken?: string;
 }
+
+// Swap Toys types
+export interface ToyListing {
+  listingId: string;
+  userId: string;
+  title: string;
+  description?: string;
+  condition: 'new' | 'like_new' | 'good' | 'fair';
+  category?: string;
+  images?: string[];
+  status: 'available' | 'swapped';
+  location?: string;
+  wantInReturn?: string;
+  createdAt: string;
+  updatedAt: string;
+  // enriched
+  userName?: string;
+}
+
+export interface ToyListingListResponse {
+  items: ToyListing[];
+  nextToken?: string;
+}
+


### PR DESCRIPTION
- Add ToyListingsTable DynamoDB table (listingId PK, UserIdIndex GSI)
- Add ToyListing model with full CRUD and offline local-storage support
- Add 5 Lambda handlers: list, create, get, update, delete (/swap-toys)
- Register handlers + table in serverless.yml with Cognito auth on write ops
- Add IAM permissions for toy-listings table to Lambda execution role
- Add ToyListing / ToyListingListResponse TypeScript types
- Add 5 API service methods in api.ts (listToyListings, createToyListing, etc.)
- Rewrite SwapToys.tsx: Browse All + My Listings tabs, post modal, pagination
- Add ToyListingCard component (condition/category badges, delete button)
- Add CreateToyListingModal with inline validation
- Add unit tests: create, list, delete handlers (17 tests, all passing)

Existing interest handler (POST /interest/swap-toys) is unchanged.