### PR TITLE
Fix browse library club filtering, add admin edit/delete permissions

### DIFF
--- a/bookclub-app/backend/.local-storage/club-members.json
+++ b/bookclub-app/backend/.local-storage/club-members.json
@@ -1,9 +1,9 @@
 {
-  "86ecd675-4caa-4755-abc2-138ae867450b:test-user-123": {
-    "clubId": "86ecd675-4caa-4755-abc2-138ae867450b",
+  "b8c33b6a-c0fc-40ce-a5f1-78984f4a2466:test-user-123": {
+    "clubId": "b8c33b6a-c0fc-40ce-a5f1-78984f4a2466",
     "userId": "test-user-123",
     "role": "admin",
-    "joinedAt": "2026-05-01T03:22:19.542Z",
+    "joinedAt": "2026-05-01T06:13:53.416Z",
     "status": "active"
   }
 }

--- a/bookclub-app/backend/.local-storage/clubs.json
+++ b/bookclub-app/backend/.local-storage/clubs.json
@@ -1,15 +1,15 @@
 {
-  "86ecd675-4caa-4755-abc2-138ae867450b": {
-    "clubId": "86ecd675-4caa-4755-abc2-138ae867450b",
+  "b8c33b6a-c0fc-40ce-a5f1-78984f4a2466": {
+    "clubId": "b8c33b6a-c0fc-40ce-a5f1-78984f4a2466",
     "name": "Test Book Club",
     "slug": "test-book-club",
     "description": "A test club",
     "createdBy": "test-user-123",
-    "inviteCode": "77889E61",
+    "inviteCode": "2CB2DCEC",
     "isPrivate": false,
     "memberLimit": null,
     "memberCount": 1,
-    "createdAt": "2026-05-01T03:22:19.542Z",
-    "updatedAt": "2026-05-01T03:22:19.542Z"
+    "createdAt": "2026-05-01T06:13:53.416Z",
+    "updatedAt": "2026-05-01T06:13:53.417Z"
   }
 }

--- a/bookclub-app/backend/src/handlers/books/delete.js
+++ b/bookclub-app/backend/src/handlers/books/delete.js
@@ -1,4 +1,6 @@
 const Book = require('../../models/book');
+const User = require('../../models/user');
+const BookClub = require('../../models/bookclub');
 const response = require('../../lib/response');
 const { getAuthenticatedUserId } = require('../../lib/get-user-id');
 
@@ -14,7 +16,26 @@ module.exports.handler = async (event) => {
       });
     }
 
-    await Book.delete(bookId, userId);
+    // Determine the effective owner for the delete call.
+    // Club admins can delete items in their club; superadmins can delete any item.
+    let effectiveUserId = userId;
+    const book = await Book.getById(bookId);
+    if (book && book.userId !== userId) {
+      const reqUser = await User.getById(userId);
+      const isSuperAdmin = reqUser?.role === 'superadmin';
+      let isClubAdmin = false;
+      if (book.clubId) {
+        try {
+          const role = await BookClub.getMemberRole(book.clubId, userId);
+          isClubAdmin = role === 'admin';
+        } catch (_) {}
+      }
+      if (isSuperAdmin || isClubAdmin) {
+        effectiveUserId = book.userId;
+      }
+    }
+
+    await Book.delete(bookId, effectiveUserId);
     return response.success({ message: 'Book deleted successfully' });
   } catch (error) {
     if (error.message.includes('not found') || error.message.includes('permission')) {

--- a/bookclub-app/backend/src/handlers/books/list.js
+++ b/bookclub-app/backend/src/handlers/books/list.js
@@ -7,24 +7,18 @@ module.exports.handler = async (event) => {
   try {
     const { qs, limit, nextToken, search, ageGroupFine, bare, filter, clubId, category } = parseQuery(event);
     const userId = deriveUserId(event, qs);
+    const authUserId = deriveAuthUserId(event);
     logListContext(event, userId, limit, nextToken, search, ageGroupFine, bare, filter, category);
 
     let result;
-    if (filter === 'borrowed' && userId) {
-      result = await Book.listByLentToUser(userId, limit, nextToken);
-    } else if (clubId) {
-      result = await listBooksByClubMembers(clubId, limit);
-    } else if (userId) {
-      result = await Book.listByUser(userId, limit, nextToken, category);
-    } else {
-      const options = { category };
-      if (bare) options.bare = true;
-      // Resolve which club IDs the requesting user is an active member of.
-      // null = unauthenticated (hide all club items). Set = membership set.
+    if (bare) {
+      // Browse library: show all items, filtered by club membership
+      const options = { category, bare: true };
       let memberClubIds = null;
-      if (userId) {
+      const effectiveUserId = authUserId || userId;
+      if (effectiveUserId) {
         try {
-          const userClubs = await BookClub.getUserClubs(userId);
+          const userClubs = await BookClub.getUserClubs(effectiveUserId);
           memberClubIds = new Set(
             (userClubs || []).filter(c => c.userStatus === 'active').map(c => c.clubId)
           );
@@ -33,6 +27,16 @@ module.exports.handler = async (event) => {
         }
       }
       options.memberClubIds = memberClubIds;
+      result = await Book.listAll(limit, nextToken, search, ageGroupFine || null, options);
+    } else if (filter === 'borrowed' && userId) {
+      result = await Book.listByLentToUser(userId, limit, nextToken);
+    } else if (clubId) {
+      result = await listBooksByClubMembers(clubId, limit);
+    } else if (userId) {
+      result = await Book.listByUser(userId, limit, nextToken, category);
+    } else {
+      const options = { category };
+      options.memberClubIds = null;
       result = await Book.listAll(limit, nextToken, search, ageGroupFine || null, options);
     }
 
@@ -65,6 +69,10 @@ const deriveUserId = (event, qs) => {
     userId = event.requestContext.authorizer.claims.sub;
   }
   return userId;
+};
+
+const deriveAuthUserId = (event) => {
+  return event?.requestContext?.authorizer?.claims?.sub || null;
 };
 
 const listBooksByClubMembers = async (clubId, limit) => {

--- a/bookclub-app/backend/src/handlers/books/update.js
+++ b/bookclub-app/backend/src/handlers/books/update.js
@@ -1,4 +1,6 @@
 const Book = require('../../models/book');
+const User = require('../../models/user');
+const BookClub = require('../../models/bookclub');
 const response = require('../../lib/response');
 const { getAuthenticatedUserId } = require('../../lib/get-user-id');
 
@@ -21,7 +23,28 @@ module.exports.handler = async (event) => {
     const validationErr = validateUpdates(updates);
     if (validationErr) return validationErr;
 
-    const updatedBook = await Book.update(bookId, userId, updates);
+    // Determine the effective owner for the update call.
+    // Club admins can edit items in their club; superadmins can edit any item.
+    let effectiveUserId = userId;
+    if (userId) {
+      const book = await Book.getById(bookId);
+      if (book && book.userId !== userId) {
+        const reqUser = await User.getById(userId);
+        const isSuperAdmin = reqUser?.role === 'superadmin';
+        let isClubAdmin = false;
+        if (book.clubId) {
+          try {
+            const role = await BookClub.getMemberRole(book.clubId, userId);
+            isClubAdmin = role === 'admin';
+          } catch (_) {}
+        }
+        if (isSuperAdmin || isClubAdmin) {
+          effectiveUserId = book.userId;
+        }
+      }
+    }
+
+    const updatedBook = await Book.update(bookId, effectiveUserId, updates);
     if (!updatedBook) {
       return response.notFound('Book not found or you do not have permission to update it');
     }

--- a/bookclub-app/frontend/src/__tests__/pages/LibraryPage.test.tsx
+++ b/bookclub-app/frontend/src/__tests__/pages/LibraryPage.test.tsx
@@ -10,7 +10,9 @@ import { useSubdomain } from '../../hooks/useSubdomain';
 jest.mock('../../services/api', () => ({
   apiService: {
     listBooksPublic: jest.fn(),
+    listBooks: jest.fn(),
     getUserClubs: jest.fn().mockResolvedValue({ items: [] }),
+    listMembers: jest.fn().mockResolvedValue({ items: [] }),
   },
 }));
 
@@ -169,7 +171,7 @@ describe('LibraryPage', () => {
       { bookId: '1', title: 'Club Book', clubId: 'club-member' },
       { bookId: '2', title: 'Non-Club Book' }
     ];
-    (apiService.listBooksPublic as jest.Mock).mockResolvedValue({ items: mockItems });
+    (apiService.listBooks as jest.Mock).mockResolvedValue({ items: mockItems });
 
     render(<LibraryPage />);
 

--- a/bookclub-app/frontend/src/pages/BookDetails.tsx
+++ b/bookclub-app/frontend/src/pages/BookDetails.tsx
@@ -23,10 +23,11 @@ const BookDetails: React.FC = () => {
   const [book, setBook] = useState<Book | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>('');
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, user, isSuperAdmin } = useAuth();
   const notificationCtx = React.useContext(NotificationContext);
   const [deleting, setDeleting] = useState(false);
   const [isMemberOfBookClub, setIsMemberOfBookClub] = useState<boolean>(false);
+  const [isClubAdmin, setIsClubAdmin] = useState<boolean>(false);
   const [joinStatus, setJoinStatus] = useState<string | null>(null);
 
   // Defensive helpers to avoid rendering non-string values (e.g., objects like {NULL: true})
@@ -219,6 +220,7 @@ const BookDetails: React.FC = () => {
         if (isAuthenticated && b.clubId) {
           const club = (userClubsRes.items || []).find((c: any) => c.clubId === b.clubId);
           setIsMemberOfBookClub(club?.userStatus === 'active');
+          setIsClubAdmin(club?.userRole === 'admin');
           if (club?.userStatus === 'pending') {
             setJoinStatus('pending');
           }
@@ -263,6 +265,7 @@ const BookDetails: React.FC = () => {
     `data:image/svg+xml,%3csvg width='300' height='400' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='300' height='400' fill='%23f3f4f6'/%3e%3ctext x='50%25' y='50%25' font-size='16' fill='%23374151' text-anchor='middle' dy='.3em'%3e${getItemLabel(book.category || 'book')}%3c/text%3e%3c/svg%3e`;
 
   const isOwner = !!(user?.userId && book.userId && user.userId === (book.userId as any));
+  const canManage = isOwner || isSuperAdmin || isClubAdmin;
   const isBook = !book.category || book.category === 'book';
 
   const handleEdit = () => {
@@ -431,7 +434,7 @@ const BookDetails: React.FC = () => {
 
           {/* Actions */}
           <div className="mt-4 sm:mt-6">
-            {isAuthenticated && isOwner ? (
+            {isAuthenticated && canManage ? (
               <div className="flex flex-wrap gap-2">
                 <button
                   type="button"

--- a/bookclub-app/frontend/src/pages/LibraryHub.tsx
+++ b/bookclub-app/frontend/src/pages/LibraryHub.tsx
@@ -30,7 +30,9 @@ const LibraryHub: React.FC = () => {
     try {
       setLoading(true);
       setError('');
-      const response = await apiService.listBooksPublic({ limit: 60, bare: true });
+      const response = isAuthenticated
+        ? await apiService.listBooks({ limit: 60, bare: true })
+        : await apiService.listBooksPublic({ limit: 60, bare: true });
       let all: Book[] = Array.isArray(response.items) ? response.items : [];
 
       if (isAuthenticated && user?.userId) {

--- a/bookclub-app/frontend/src/pages/LibraryPage.tsx
+++ b/bookclub-app/frontend/src/pages/LibraryPage.tsx
@@ -49,15 +49,18 @@ const LibraryPage: React.FC<LibraryPageProps> = ({ config: propConfig }) => {
       setLoading(true);
       setError('');
       
-      const response = await apiService.listBooksPublic({
+      const browseParams = {
         limit: currentPageSize || PAGE_SIZE,
         nextToken: token || undefined,
         search: search || undefined,
         // If it's a subdomain, filter by club
         clubId: (isSubdomain && club) ? club.clubId : undefined,
         // Filter by category
-        bare: true,
-      });
+        bare: true as const,
+      };
+      const response = isAuthenticated
+        ? await apiService.listBooks(browseParams)
+        : await apiService.listBooksPublic(browseParams);
 
       let items = Array.isArray(response.items) ? response.items : [];
       

--- a/bookclub-app/frontend/src/services/api.ts
+++ b/bookclub-app/frontend/src/services/api.ts
@@ -273,6 +273,8 @@ class ApiService {
     limit?: number;
     nextToken?: string;
     filter?: 'borrowed';
+    bare?: boolean;
+    search?: string;
   }): Promise<BookListResponse> {
     const queryParams = new URLSearchParams();
     if (params?.userId) queryParams.append('userId', params.userId);
@@ -280,6 +282,8 @@ class ApiService {
     if (params?.limit) queryParams.append('limit', params.limit.toString());
     if (params?.nextToken) queryParams.append('nextToken', params.nextToken);
     if (params?.filter) queryParams.append('filter', params.filter);
+    if (params?.bare) queryParams.append('bare', '1');
+    if (params?.search) queryParams.append('search', params.search);
 
     const response: AxiosResponse<ApiResponse<BookListResponse>> = await this.api.get(
       `/books?${queryParams.toString()}`


### PR DESCRIPTION
Backend:
- list.js: route bare=true (browse) to listAll with memberClubIds; add deriveAuthUserId for auth-only userId
- update.js/delete.js: club admins can edit/delete items in their club; superadmins can edit/delete any item

Frontend:
- LibraryHub/LibraryPage: use authenticated listBooks when logged in so backend resolves club membership
- api.ts: add bare/search params to listBooks
- BookDetails: show Edit/Delete for club admins and superadmins (canManage)
- LibraryPage.test.tsx: add listBooks mock for authenticated test