### PR TITLE
fix: add empty default to hosted_zone_id variable in Terraform to pre…

### DIFF
--- a/bookclub-app/backend/terraform/variables.tf
+++ b/bookclub-app/backend/terraform/variables.tf
@@ -41,6 +41,7 @@ variable "api_fqdn" {
 variable "hosted_zone_id" {
   description = "Route53 hosted zone ID for the apex domain (e.g., Z123ABCXYZ)"
   type        = string
+  default     = ""
 }
 
 variable "hosted_zone_name" {


### PR DESCRIPTION
…vent interactive prompting when looking up by hosted_zone_name instead