### PR TITLE
fix: set CI=false in deployment workflows to prevent ESLint warnings …

### DIFF
--- a/.github/workflows/deploy-australia.yml
+++ b/.github/workflows/deploy-australia.yml
@@ -64,6 +64,7 @@ jobs:
         working-directory: bookclub-app/frontend
         env:
           DEPLOY_TARGET: australia
+          CI: false
         run: |
           # Fetch dynamic values from serverless output
           cd ../backend

--- a/.github/workflows/deploy-india.yml
+++ b/.github/workflows/deploy-india.yml
@@ -64,6 +64,7 @@ jobs:
         working-directory: bookclub-app/frontend
         env:
           DEPLOY_TARGET: india
+          CI: false
         run: |
           # Fetch dynamic values from serverless output
           cd ../backend


### PR DESCRIPTION
…from failing the frontend production build