### PR TITLE
fix: remove allowCredentials:true from all CORS configs — JWT auth us…

### DIFF
--- a/bookclub-app/backend/serverless.yml
+++ b/bookclub-app/backend/serverless.yml
@@ -187,7 +187,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -211,7 +210,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
       - eventBridge:
           eventBus: ${self:provider.environment.EVENT_BUS_NAME}
           pattern:
@@ -259,7 +257,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -280,7 +277,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -301,7 +297,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -323,7 +318,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -344,7 +338,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -365,7 +358,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -386,7 +378,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -407,7 +398,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -428,7 +418,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -449,7 +438,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
 
   listBooks:
     handler: src/handlers/books/list.handler
@@ -466,7 +454,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
 
   updateBook:
     handler: src/handlers/books/update.handler
@@ -483,7 +470,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -504,7 +490,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -526,7 +511,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -548,7 +532,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
   
   loginUser:
     handler: src/handlers/users/login.handler
@@ -565,7 +548,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
   
   getUserProfile:
     handler: src/handlers/users/getProfile.handler
@@ -582,7 +564,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -603,7 +584,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -625,7 +605,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -646,7 +625,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -668,7 +646,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -690,7 +667,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -711,7 +687,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -732,7 +707,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -754,7 +728,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -776,7 +749,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -887,7 +859,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -907,7 +878,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
 
   getClub:
     handler: src/handlers/clubs/get.handler
@@ -924,7 +894,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
 
   listUserClubs:
     handler: src/handlers/clubs/list.handler
@@ -941,7 +910,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -962,7 +930,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -983,7 +950,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -1004,7 +970,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1025,7 +990,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1047,7 +1011,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
 
   # Admin endpoints to manage join requests
   listJoinRequests:
@@ -1065,7 +1028,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1086,7 +1048,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1107,7 +1068,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1128,7 +1088,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1149,7 +1108,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1170,7 +1128,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1188,7 +1145,6 @@ functions:
               - Content-Type
               - Authorization
               - X-Access-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1206,7 +1162,6 @@ functions:
               - Content-Type
               - Authorization
               - X-Access-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1224,7 +1179,6 @@ functions:
               - Content-Type
               - Authorization
               - X-Access-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1246,7 +1200,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1268,7 +1221,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
 
   getLostFound:
     handler: src/handlers/lost-found/get.handler
@@ -1298,7 +1250,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1319,7 +1270,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1340,7 +1290,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1361,7 +1310,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer:
             type: COGNITO_USER_POOLS
             authorizerId:
@@ -1415,7 +1363,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
           authorizer: 
             type: COGNITO_USER_POOLS
             authorizerId: 
@@ -1432,7 +1379,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
 
 
   # Contact form (public, no auth)
@@ -1451,7 +1397,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
 
   # Public sitemap.xml
   sitemap:
@@ -1469,7 +1414,6 @@ functions:
               - X-Amz-Date
               - X-Api-Key
               - X-Amz-Security-Token
-            allowCredentials: true
 
 resources:
   Resources:


### PR DESCRIPTION
…es Authorization header, not cookies; wildcard origin is only valid without credentials