### PR TITLE
fix(events): provision bookclub-events DDB table and fix getById to u…

### DIFF
--- a/bookclub-app/backend/serverless.yml
+++ b/bookclub-app/backend/serverless.yml
@@ -2269,6 +2269,37 @@ resources:
               ReadCapacityUnits: 5
               WriteCapacityUnits: 5
 
+    BookclubEventsTable:
+      Type: AWS::CloudFormation::CustomResource
+      DeletionPolicy: Retain
+      UpdateReplacePolicy: Retain
+      Properties:
+        ServiceToken: !GetAtt DynamoTableManagerLambdaFunction.Arn
+        TableName: ${self:service}-bookclub-events-${self:provider.stage}
+        AttributeDefinitions:
+          - AttributeName: clubId
+            AttributeType: S
+          - AttributeName: eventId
+            AttributeType: S
+        KeySchema:
+          - AttributeName: clubId
+            KeyType: HASH
+          - AttributeName: eventId
+            KeyType: RANGE
+        GlobalSecondaryIndexes:
+          - IndexName: EventIdIndex
+            KeySchema:
+              - AttributeName: eventId
+                KeyType: HASH
+            Projection:
+              ProjectionType: ALL
+            ProvisionedThroughput:
+              ReadCapacityUnits: 5
+              WriteCapacityUnits: 5
+        ProvisionedThroughput:
+          ReadCapacityUnits: 5
+          WriteCapacityUnits: 5
+
     ClubEmailInvitesTable:
       Type: AWS::CloudFormation::CustomResource
       DeletionPolicy: Retain

--- a/bookclub-app/backend/src/models/event.js
+++ b/bookclub-app/backend/src/models/event.js
@@ -190,7 +190,16 @@ class Event {
     if (isOffline()) {
       return LocalStorage.getEvent(eventId);
     }
-    return dynamoDb.get(getTableName('bookclub-events'), { eventId });
+    // Table primary key is composite (clubId HASH + eventId RANGE),
+    // so we use the EventIdIndex GSI to look up by eventId alone.
+    const result = await dynamoDb.query({
+      TableName: getTableName('bookclub-events'),
+      IndexName: 'EventIdIndex',
+      KeyConditionExpression: 'eventId = :eventId',
+      ExpressionAttributeValues: { ':eventId': eventId },
+      Limit: 1,
+    });
+    return (result.Items && result.Items[0]) || null;
   }
 
   static async listByClub(clubId) {


### PR DESCRIPTION
…se GSI

- Add BookclubEventsTable CloudFormation resource (was missing, causing 500 on GET /clubs/{clubId}/events)
- Schema: clubId (HASH) + eventId (RANGE) with EventIdIndex GSI
- Update Event.getById to query EventIdIndex since table has composite PK