### PR TITLE
feat(events): high-priority improvements to recurring events

### DIFF
--- a/bookclub-app/backend/__tests__/unit/handlers/events/delete.test.js
+++ b/bookclub-app/backend/__tests__/unit/handlers/events/delete.test.js
@@ -80,6 +80,72 @@ describe('events.delete handler', () => {
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
     expect(body.data.message).toBe('Event deleted successfully');
+    expect(body.data.seriesDeleted).toBe(false);
     expect(Event.delete).toHaveBeenCalledWith('event-1');
+    expect(Event.deleteSeries).not.toHaveBeenCalled();
+  });
+
+  it('deletes the whole series when deleteSeries=true on a parent event', async () => {
+    const event = {
+      pathParameters: { clubId: 'club-1', eventId: 'parent-1' },
+      queryStringParameters: { deleteSeries: 'true' },
+      userId: 'user-1',
+    };
+
+    Event.getById.mockResolvedValue({
+      eventId: 'parent-1',
+      clubId: 'club-1',
+      createdBy: 'user-1',
+      recurrencePattern: 'weekly',
+    });
+    Event.deleteSeries.mockResolvedValue(true);
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.data.message).toBe('Event series deleted successfully');
+    expect(body.data.seriesDeleted).toBe(true);
+    expect(Event.deleteSeries).toHaveBeenCalledWith('parent-1');
+    expect(Event.delete).not.toHaveBeenCalled();
+  });
+
+  it('uses parentEventId when deleting a child event with deleteSeries=true', async () => {
+    const event = {
+      pathParameters: { clubId: 'club-1', eventId: 'child-2' },
+      queryStringParameters: { deleteSeries: 'true' },
+      userId: 'user-1',
+    };
+
+    Event.getById.mockResolvedValue({
+      eventId: 'child-2',
+      clubId: 'club-1',
+      createdBy: 'user-1',
+      parentEventId: 'parent-1',
+    });
+    Event.deleteSeries.mockResolvedValue(true);
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    expect(Event.deleteSeries).toHaveBeenCalledWith('parent-1');
+  });
+
+  it('returns 500 when deleteSeries fails', async () => {
+    const event = {
+      pathParameters: { clubId: 'club-1', eventId: 'parent-1' },
+      queryStringParameters: { deleteSeries: 'true' },
+      userId: 'user-1',
+    };
+
+    Event.getById.mockResolvedValue({
+      eventId: 'parent-1',
+      clubId: 'club-1',
+      createdBy: 'user-1',
+      recurrencePattern: 'weekly',
+    });
+    Event.deleteSeries.mockResolvedValue(false);
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body).error.message).toBe('Failed to delete event series');
   });
 });

--- a/bookclub-app/backend/__tests__/unit/handlers/events/update.test.js
+++ b/bookclub-app/backend/__tests__/unit/handlers/events/update.test.js
@@ -120,5 +120,84 @@ describe('events.update handler', () => {
       location: 'Community Library Room B',
       volunteerTasks: ['Bring snacks', 'Setup chairs'],
     });
+    expect(Event.updateSeriesFrom).not.toHaveBeenCalled();
+  });
+
+  it('updates the whole series when updateSeries=true on a parent event', async () => {
+    const event = {
+      pathParameters: { clubId: 'club-1', eventId: 'parent-1' },
+      queryStringParameters: { updateSeries: 'true' },
+      userId: 'user-1',
+      body: JSON.stringify({ title: 'Series Title' }),
+    };
+
+    const parent = {
+      eventId: 'parent-1',
+      clubId: 'club-1',
+      createdBy: 'user-1',
+      recurrencePattern: 'weekly',
+    };
+    const updated = [
+      { ...parent, title: 'Series Title' },
+      { eventId: 'child-2', clubId: 'club-1', createdBy: 'user-1', parentEventId: 'parent-1', title: 'Series Title' },
+    ];
+
+    Event.getById.mockResolvedValue(parent);
+    Event.updateSeriesFrom.mockResolvedValue(updated);
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.data.seriesUpdated).toBe(true);
+    expect(body.data.updatedCount).toBe(2);
+    expect(body.data.events).toEqual(updated);
+    expect(Event.updateSeriesFrom).toHaveBeenCalledWith('parent-1', { title: 'Series Title' });
+    expect(Event.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the series when updateSeries=true on a child event', async () => {
+    const event = {
+      pathParameters: { clubId: 'club-1', eventId: 'child-2' },
+      queryStringParameters: { updateSeries: 'true' },
+      userId: 'user-1',
+      body: JSON.stringify({ location: 'New Place' }),
+    };
+
+    Event.getById.mockResolvedValue({
+      eventId: 'child-2',
+      clubId: 'club-1',
+      createdBy: 'user-1',
+      parentEventId: 'parent-1',
+    });
+    Event.updateSeriesFrom.mockResolvedValue([]);
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    expect(Event.updateSeriesFrom).toHaveBeenCalledWith('child-2', { location: 'New Place' });
+  });
+
+  it('falls back to single event update when updateSeries=true but event is not part of a series', async () => {
+    const event = {
+      pathParameters: { clubId: 'club-1', eventId: 'event-1' },
+      queryStringParameters: { updateSeries: 'true' },
+      userId: 'user-1',
+      body: JSON.stringify({ title: 'Solo Update' }),
+    };
+
+    const existing = {
+      eventId: 'event-1',
+      clubId: 'club-1',
+      createdBy: 'user-1',
+      recurrencePattern: 'none',
+    };
+    Event.getById.mockResolvedValue(existing);
+    Event.update.mockResolvedValue({ ...existing, title: 'Solo Update' });
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.data.seriesUpdated).toBe(false);
+    expect(Event.update).toHaveBeenCalled();
+    expect(Event.updateSeriesFrom).not.toHaveBeenCalled();
   });
 });

--- a/bookclub-app/backend/__tests__/unit/models/event.test.js
+++ b/bookclub-app/backend/__tests__/unit/models/event.test.js
@@ -1,0 +1,281 @@
+// Use local storage path for model tests
+process.env.IS_OFFLINE = 'true';
+process.env.NODE_ENV = 'development';
+
+const path = require('path');
+const fs = require('fs');
+
+const Event = require('../../../src/models/event');
+
+const STORAGE_DIR = path.join(__dirname, '../../../.local-storage');
+const EVENTS_FILE = path.join(STORAGE_DIR, 'events.json');
+
+function clearEventsFile() {
+  try {
+    if (fs.existsSync(EVENTS_FILE)) fs.unlinkSync(EVENTS_FILE);
+  } catch (_) {
+    // ignore
+  }
+}
+
+describe('Event model', () => {
+  beforeEach(() => {
+    clearEventsFile();
+  });
+
+  afterAll(() => {
+    clearEventsFile();
+  });
+
+  describe('generateRecurringDates', () => {
+    test('returns only the start date for pattern "none"', () => {
+      const dates = Event.generateRecurringDates(
+        '2026-06-01T18:00:00.000Z',
+        'none',
+        '2026-08-01'
+      );
+      expect(dates).toHaveLength(1);
+      expect(dates[0]).toBe(new Date('2026-06-01T18:00:00.000Z').toISOString());
+    });
+
+    test('generates weekly occurrences up to the end date', () => {
+      const start = '2026-06-01T18:00:00.000Z';
+      const dates = Event.generateRecurringDates(start, 'weekly', '2026-06-29');
+      // 06-01, 06-08, 06-15, 06-22, 06-29 = 5 dates
+      expect(dates).toHaveLength(5);
+      expect(new Date(dates[1]).getUTCDate()).toBe(8);
+      expect(new Date(dates[4]).getUTCDate()).toBe(29);
+    });
+
+    test('generates biweekly occurrences', () => {
+      const dates = Event.generateRecurringDates(
+        '2026-06-01T18:00:00.000Z',
+        'biweekly',
+        '2026-07-13'
+      );
+      // 06-01, 06-15, 06-29, 07-13 = 4
+      expect(dates).toHaveLength(4);
+    });
+
+    test('generates monthly occurrences', () => {
+      const dates = Event.generateRecurringDates(
+        '2026-06-01T18:00:00.000Z',
+        'monthly',
+        '2026-09-01'
+      );
+      // 06-01, 07-01, 08-01, 09-01 = 4
+      expect(dates).toHaveLength(4);
+    });
+
+    test('generates daily occurrences', () => {
+      const dates = Event.generateRecurringDates(
+        '2026-06-01T18:00:00.000Z',
+        'daily',
+        '2026-06-05'
+      );
+      expect(dates).toHaveLength(5);
+    });
+
+    test('caps occurrences at 26 weeks from start even if endDate is later', () => {
+      const start = '2026-06-01T18:00:00.000Z';
+      const farFuture = '2027-06-01'; // ~52 weeks out
+      const dates = Event.generateRecurringDates(start, 'weekly', farFuture);
+      // 26 weeks => roughly 26-27 occurrences
+      expect(dates.length).toBeGreaterThanOrEqual(26);
+      expect(dates.length).toBeLessThanOrEqual(27);
+      const last = new Date(dates[dates.length - 1]);
+      const startMs = new Date(start).getTime();
+      const diffWeeks = (last.getTime() - startMs) / (7 * 24 * 60 * 60 * 1000);
+      expect(diffWeeks).toBeLessThanOrEqual(26);
+    });
+
+    test('returns empty array when end date is before start', () => {
+      const dates = Event.generateRecurringDates(
+        '2026-06-01T18:00:00.000Z',
+        'weekly',
+        '2026-05-01'
+      );
+      expect(dates).toHaveLength(0);
+    });
+  });
+
+  describe('createSeries', () => {
+    const userId = 'u1';
+    const userName = 'Alice';
+
+    test('creates a single event when pattern is "none"', async () => {
+      const events = await Event.createSeries(
+        {
+          clubId: 'c1',
+          title: 'One-off',
+          dateTime: '2026-06-01T18:00:00.000Z',
+          recurrencePattern: 'none',
+        },
+        userId,
+        userName
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0].parentEventId).toBeNull();
+      expect(events[0].recurrencePattern).toBe('none');
+    });
+
+    test('creates a single event when no recurrenceEndDate is provided', async () => {
+      const events = await Event.createSeries(
+        {
+          clubId: 'c1',
+          title: 'Weekly?',
+          dateTime: '2026-06-01T18:00:00.000Z',
+          recurrencePattern: 'weekly',
+        },
+        userId,
+        userName
+      );
+      expect(events).toHaveLength(1);
+    });
+
+    test('creates parent + children with proper linkage for weekly series', async () => {
+      const events = await Event.createSeries(
+        {
+          clubId: 'c1',
+          title: 'Weekly Meeting',
+          dateTime: '2026-06-01T18:00:00.000Z',
+          recurrencePattern: 'weekly',
+          recurrenceEndDate: '2026-06-22',
+        },
+        userId,
+        userName
+      );
+
+      // 06-01, 06-08, 06-15, 06-22 = 4
+      expect(events).toHaveLength(4);
+
+      const [parent, ...children] = events;
+      expect(parent.parentEventId).toBeNull();
+      expect(parent.recurrencePattern).toBe('weekly');
+      expect(parent.recurrenceEndDate).toBe('2026-06-22');
+
+      for (const child of children) {
+        expect(child.parentEventId).toBe(parent.eventId);
+        expect(child.recurrencePattern).toBe('none');
+        expect(child.recurrenceEndDate).toBeNull();
+        expect(child.isRecurringInstance).toBe(true);
+      }
+    });
+  });
+
+  describe('getSeries', () => {
+    test('returns parent + all children sorted by dateTime', async () => {
+      const [parent] = await Event.createSeries(
+        {
+          clubId: 'c1',
+          title: 'S1',
+          dateTime: '2026-06-01T18:00:00.000Z',
+          recurrencePattern: 'weekly',
+          recurrenceEndDate: '2026-06-15',
+        },
+        'u1',
+        'Alice'
+      );
+
+      const series = await Event.getSeries(parent.eventId);
+      expect(series).toHaveLength(3);
+      // First item is the parent (earliest date)
+      expect(series[0].eventId).toBe(parent.eventId);
+      // Sorted ascending by dateTime
+      for (let i = 1; i < series.length; i++) {
+        expect(new Date(series[i].dateTime).getTime()).toBeGreaterThan(
+          new Date(series[i - 1].dateTime).getTime()
+        );
+      }
+    });
+
+    test('returns empty array when parent does not exist', async () => {
+      const series = await Event.getSeries('nonexistent-id');
+      expect(series).toEqual([]);
+    });
+  });
+
+  describe('updateSeriesFrom', () => {
+    test('updates only this and future events, leaving past events alone', async () => {
+      const events = await Event.createSeries(
+        {
+          clubId: 'c1',
+          title: 'Orig',
+          description: 'Orig desc',
+          dateTime: '2026-06-01T18:00:00.000Z',
+          recurrencePattern: 'weekly',
+          recurrenceEndDate: '2026-06-22',
+        },
+        'u1',
+        'Alice'
+      );
+      expect(events).toHaveLength(4);
+
+      // Update from the 3rd occurrence (2026-06-15) onward
+      const fromId = events[2].eventId;
+      const updated = await Event.updateSeriesFrom(fromId, { title: 'Changed' });
+      expect(updated).toHaveLength(2); // 06-15 and 06-22
+
+      // Verify in storage
+      const allInSeries = await Event.getSeries(events[0].eventId);
+      expect(allInSeries[0].title).toBe('Orig');
+      expect(allInSeries[1].title).toBe('Orig');
+      expect(allInSeries[2].title).toBe('Changed');
+      expect(allInSeries[3].title).toBe('Changed');
+    });
+
+    test('does not allow dateTime or recurrence fields to be changed', async () => {
+      const events = await Event.createSeries(
+        {
+          clubId: 'c1',
+          title: 'T',
+          dateTime: '2026-06-01T18:00:00.000Z',
+          recurrencePattern: 'weekly',
+          recurrenceEndDate: '2026-06-15',
+        },
+        'u1',
+        'Alice'
+      );
+      const originalDates = events.map(e => e.dateTime);
+
+      await Event.updateSeriesFrom(events[0].eventId, {
+        title: 'New',
+        dateTime: '2099-01-01T00:00:00.000Z',
+        recurrencePattern: 'daily',
+        recurrenceEndDate: '2099-12-31',
+      });
+
+      const series = await Event.getSeries(events[0].eventId);
+      series.forEach((evt, idx) => {
+        expect(evt.dateTime).toBe(originalDates[idx]);
+      });
+      // recurrencePattern on parent should remain weekly
+      expect(series[0].recurrencePattern).toBe('weekly');
+    });
+  });
+
+  describe('deleteSeries', () => {
+    test('deletes parent and all children', async () => {
+      const events = await Event.createSeries(
+        {
+          clubId: 'c1',
+          title: 'D',
+          dateTime: '2026-06-01T18:00:00.000Z',
+          recurrencePattern: 'weekly',
+          recurrenceEndDate: '2026-06-15',
+        },
+        'u1',
+        'Alice'
+      );
+      expect(events).toHaveLength(3);
+
+      const ok = await Event.deleteSeries(events[0].eventId);
+      expect(ok).toBe(true);
+
+      for (const evt of events) {
+        const found = await Event.getById(evt.eventId);
+        expect(found).toBeNull();
+      }
+    });
+  });
+});

--- a/bookclub-app/backend/src/models/event.js
+++ b/bookclub-app/backend/src/models/event.js
@@ -49,8 +49,14 @@ class Event {
   static generateRecurringDates(startDate, pattern, maxDate) {
     const dates = [];
     const start = new Date(startDate);
+    // Interpret maxDate as inclusive of the entire day. If the input is a
+    // YYYY-MM-DD string (no time component), shift to end-of-day UTC so events
+    // occurring later in the day on the end date are still included.
     const max = new Date(maxDate);
-    
+    if (typeof maxDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(maxDate)) {
+      max.setUTCHours(23, 59, 59, 999);
+    }
+
     // Limit to 26 weeks from start
     const twentySixWeeksFromStart = new Date(start.getTime() + 26 * 7 * 24 * 60 * 60 * 1000);
     const effectiveMax = max < twentySixWeeksFromStart ? max : twentySixWeeksFromStart;
@@ -123,24 +129,33 @@ class Event {
     return events;
   }
 
-  // Get all events in a series
+  // Get all events in a series (parent + children)
   static async getSeries(parentEventId) {
     if (isOffline()) {
-      const allEvents = await LocalStorage.listEventsByClub(null);
-      return (allEvents || []).filter(e => 
+      const parent = await LocalStorage.getEvent(parentEventId);
+      if (!parent) return [];
+      const allEvents = await LocalStorage.listEventsByClub(parent.clubId);
+      return (allEvents || []).filter(e =>
         e.eventId === parentEventId || e.parentEventId === parentEventId
-      );
+      ).sort((a, b) => new Date(a.dateTime) - new Date(b.dateTime));
     }
-    
-    // Query by parentEventId using a GSI scan fallback
-    const scanParams = {
+
+    // Look up the parent event via EventIdIndex GSI to discover its clubId.
+    const parent = await this.getById(parentEventId);
+    if (!parent) return [];
+
+    // Query within the club partition (efficient) and filter for series members.
+    const result = await dynamoDb.query({
       TableName: getTableName('bookclub-events'),
+      KeyConditionExpression: 'clubId = :clubId',
       FilterExpression: 'eventId = :parentId OR parentEventId = :parentId',
-      ExpressionAttributeValues: { ':parentId': parentEventId },
-    };
-    
-    const result = await dynamoDb.scan(scanParams);
-    return (result.Items || []).sort((a, b) => 
+      ExpressionAttributeValues: {
+        ':clubId': parent.clubId,
+        ':parentId': parentEventId,
+      },
+    });
+
+    return (result.Items || []).sort((a, b) =>
       new Date(a.dateTime) - new Date(b.dateTime)
     );
   }

--- a/bookclub-app/frontend/src/components/ClubProtectedRoute.tsx
+++ b/bookclub-app/frontend/src/components/ClubProtectedRoute.tsx
@@ -8,7 +8,7 @@ interface ClubProtectedRouteProps {
 }
 
 const ClubProtectedRoute: React.FC<ClubProtectedRouteProps> = ({ children }) => {
-  const { hasClubAccess, loading } = useAuth();
+  const { canAccessClubs, loading } = useAuth();
 
   if (loading) {
     return (
@@ -21,7 +21,7 @@ const ClubProtectedRoute: React.FC<ClubProtectedRouteProps> = ({ children }) => 
     );
   }
 
-  if (!hasClubAccess) {
+  if (!canAccessClubs) {
     return <Navigate to="/library" replace />;
   }
 

--- a/bookclub-app/frontend/src/components/MobileTabBar.tsx
+++ b/bookclub-app/frontend/src/components/MobileTabBar.tsx
@@ -5,7 +5,7 @@ import { useUploadModal } from '../contexts/UploadModalContext';
 import { apiService } from '../services/api';
 
 const MobileTabBar: React.FC = () => {
-  const { isAuthenticated, user, hasClubAccess } = useAuth();
+  const { isAuthenticated, user, canAccessClubs } = useAuth();
   const { openModal } = useUploadModal();
   const location = useLocation();
   const [unreadCount, setUnreadCount] = useState(0);
@@ -77,7 +77,7 @@ const MobileTabBar: React.FC = () => {
 
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 shadow-inner md:hidden z-40">
-      <div className={`max-w-7xl mx-auto grid ${hasClubAccess ? 'grid-cols-5' : 'grid-cols-4'} text-[10px]`}>
+      <div className={`max-w-7xl mx-auto grid ${canAccessClubs ? 'grid-cols-5' : 'grid-cols-4'} text-[10px]`}>
         <Link
           to="/library"
           className={`flex flex-col items-center justify-center py-2 gap-0.5 transition-colors ${isActive('/library') && !isLostFoundPath ? 'text-indigo-700' : 'text-gray-600'}`}
@@ -106,7 +106,7 @@ const MobileTabBar: React.FC = () => {
           </button>
         )}
 
-        {hasClubAccess && (
+        {canAccessClubs && (
           <Link
             to="/clubs"
             className={`flex flex-col items-center justify-center py-2 gap-0.5 transition-colors ${isActive('/clubs') ? 'text-indigo-700' : 'text-gray-600'}`}

--- a/bookclub-app/frontend/src/components/Navbar.tsx
+++ b/bookclub-app/frontend/src/components/Navbar.tsx
@@ -9,7 +9,7 @@ import { config } from '../config';
 import MobileTabBar from './MobileTabBar';
 
 const Navbar: React.FC = () => {
-  const { isAuthenticated, user, logout, hasClubAccess } = useAuth();
+  const { isAuthenticated, user, logout, canAccessClubs } = useAuth();
   const { name: brandName } = useBrand();
   const { openModal } = useUploadModal();
   const location = useLocation();
@@ -135,7 +135,7 @@ const Navbar: React.FC = () => {
                 🧾 Lost & Found
               </Link>
 
-              {hasClubAccess && (
+              {canAccessClubs && (
                 <Link
                   to="/clubs"
                   className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
@@ -146,7 +146,7 @@ const Navbar: React.FC = () => {
                 </Link>
               )}
 
-              {hasClubAccess && (
+              {canAccessClubs && (
                 <Link
                   to="/events"
                   className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${

--- a/bookclub-app/frontend/src/contexts/AuthContext.tsx
+++ b/bookclub-app/frontend/src/contexts/AuthContext.tsx
@@ -14,7 +14,14 @@ interface AuthContextType {
   logoutWithSessionExpired: () => void;
   isAuthenticated: boolean;
   isSuperAdmin: boolean;
+  /** True if the user is on the allow-list to create clubs (superadmin, @dev, or curated emails). */
   hasClubAccess: boolean;
+  /** True if the user is a member of at least one club (independent of create-permissions). */
+  isClubMember: boolean;
+  /** True if the user can view club/event pages (creator or member). */
+  canAccessClubs: boolean;
+  /** Refresh the membership flag (e.g., after joining/leaving a club). */
+  refreshClubMembership: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -34,6 +41,7 @@ interface AuthProviderProps {
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [isClubMember, setIsClubMember] = useState(false);
   const { addNotification } = useNotification();
 
   const logout = () => {
@@ -50,6 +58,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     eraseCookie('user', domain);
     
     setUser(null);
+    setIsClubMember(false);
   };
 
   const logoutWithSessionExpired = useCallback(() => {
@@ -190,6 +199,31 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     return ALLOWED_CLUB_EMAILS.includes(user.email?.toLowerCase());
   }, [user, ALLOWED_CLUB_EMAILS]);
 
+  const refreshClubMembership = useCallback(async () => {
+    if (!user) {
+      setIsClubMember(false);
+      return;
+    }
+    try {
+      const result = await apiService.getUserClubs();
+      const clubs = result?.items || [];
+      setIsClubMember(clubs.length > 0);
+    } catch (_e) {
+      // Non-fatal: keep previous flag on transient errors
+    }
+  }, [user]);
+
+  // Refresh club membership whenever the authenticated user changes
+  useEffect(() => {
+    if (user) {
+      refreshClubMembership();
+    } else {
+      setIsClubMember(false);
+    }
+  }, [user, refreshClubMembership]);
+
+  const canAccessClubs = hasClubAccess || isClubMember;
+
   const value: AuthContextType = {
     user,
     loading,
@@ -199,6 +233,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     isAuthenticated: !!user,
     isSuperAdmin: user?.role === 'superadmin',
     hasClubAccess,
+    isClubMember,
+    canAccessClubs,
+    refreshClubMembership,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/bookclub-app/frontend/src/pages/ClubEvents.tsx
+++ b/bookclub-app/frontend/src/pages/ClubEvents.tsx
@@ -15,6 +15,7 @@ import {
   CheckIcon,
   PaperAirplaneIcon,
   ArrowLeftIcon,
+  ArrowPathIcon,
   MapPinIcon
 } from '@heroicons/react/24/outline';
 
@@ -860,6 +861,23 @@ const ClubEvents: React.FC = () => {
                       <h2 className="text-2xl font-black text-gray-900 tracking-tight uppercase italic">
                         {selectedEvent.title}
                       </h2>
+                      {(selectedEvent.parentEventId || (selectedEvent.recurrencePattern && selectedEvent.recurrencePattern !== 'none')) && (
+                        <div className="mt-2 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-indigo-50 border border-indigo-200 text-indigo-700 text-xs font-bold uppercase tracking-wider">
+                          <ArrowPathIcon className="h-3.5 w-3.5" />
+                          {(() => {
+                            const pattern = selectedEvent.parentEventId
+                              ? events.find(e => e.eventId === selectedEvent.parentEventId)?.recurrencePattern
+                              : selectedEvent.recurrencePattern;
+                            const label: Record<string, string> = {
+                              daily: 'Repeats Daily',
+                              weekly: 'Repeats Weekly',
+                              biweekly: 'Repeats Bi-Weekly',
+                              monthly: 'Repeats Monthly',
+                            };
+                            return label[pattern || ''] || 'Part of a Series';
+                          })()}
+                        </div>
+                      )}
                       <div className="mt-3 flex flex-wrap items-center gap-y-2 gap-x-4 text-xs font-bold uppercase tracking-wider text-gray-400">
                         <span className="flex items-center gap-1">
                           <CalendarIcon className="h-4 w-4 text-indigo-500" />

--- a/bookclub-app/frontend/src/pages/Clubs.tsx
+++ b/bookclub-app/frontend/src/pages/Clubs.tsx
@@ -17,7 +17,7 @@ const Clubs: React.FC = () => {
   const [clubs, setClubs] = useState<BookClub[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const { user, hasClubAccess } = useAuth();
+  const { user, hasClubAccess, refreshClubMembership } = useAuth();
   const { addNotification } = useNotification();
   const [editingClub, setEditingClub] = useState<BookClub | null>(null);
   const [showJoin, setShowJoin] = useState(false);
@@ -223,7 +223,7 @@ const Clubs: React.FC = () => {
         {showJoin && (
           <JoinClubModal
             onClose={() => setShowJoin(false)}
-            onClubJoined={async (club) => { setShowJoin(false); await load(); }}
+            onClubJoined={async (club) => { setShowJoin(false); await load(); await refreshClubMembership(); }}
           />
         )}
 
@@ -233,6 +233,7 @@ const Clubs: React.FC = () => {
             onClubCreated={async (newClub) => {
               setShowCreate(false);
               await load();
+              await refreshClubMembership();
               addNotification('success', `Club "${newClub.name}" created successfully`);
             }}
           />


### PR DESCRIPTION
Backend:
- Optimize Event.getSeries to use Query within club partition instead of full-table Scan, leveraging EventIdIndex GSI to discover the parent's clubId first
- Fix offline getSeries which was calling listEventsByClub(null) and returning an empty array
- Make recurrenceEndDate inclusive of the entire day (YYYY-MM-DD inputs now extend to end-of-day UTC instead of midnight)
- Add unit tests for Event model series methods (generateRecurringDates, createSeries, getSeries, updateSeriesFrom, deleteSeries) - 15 tests
- Add handler tests for updateSeries=true and deleteSeries=true query params covering parent, child, and non-series fall-back cases

Frontend:
- Add 'Repeats Weekly/Daily/Monthly/Bi-Weekly' badge with refresh icon on event detail page so users can see at a glance that an event is part of a recurring series

All 337 backend tests pass, all 13 ClubEvents frontend tests pass.