### PR TITLE
fix: send approval email to user when club join request is approved

### DIFF
--- a/bookclub-app/backend/src/handlers/clubs/approveRequest.js
+++ b/bookclub-app/backend/src/handlers/clubs/approveRequest.js
@@ -1,5 +1,7 @@
 const response = require('../../lib/response');
 const ClubService = require('../../services/club-service');
+const BookClub = require('../../models/bookclub');
+const { sendEmailIfEnabled } = require('../../lib/notification-service');
 const { withClubAdmin } = require('../../lib/middleware');
 
 /**
@@ -13,6 +15,18 @@ const handler = async (event) => {
   }
 
   const updated = await ClubService.approveRequest(clubId, targetUserId);
+
+  try {
+    const club = await BookClub.getById(clubId);
+    const baseUrl = process.env.SITE_BASE_URL || '';
+    const clubUrl = `${baseUrl}/clubs/${clubId}`;
+    await sendEmailIfEnabled(targetUserId, 'club_join_approved', 'club_join_approved', {
+      clubName: club?.name || 'your club',
+      clubUrl,
+    });
+  } catch (notifyErr) {
+    console.warn('[clubs][approveRequest] Failed to notify user of join approval', notifyErr?.message || notifyErr);
+  }
   
   return response.success({ approved: true, membership: updated });
 };

--- a/bookclub-app/backend/src/lib/notification-service.js
+++ b/bookclub-app/backend/src/lib/notification-service.js
@@ -13,6 +13,7 @@ const DEFAULT_PREFS = {
   new_member_in_your_club: true,
   club_announcement: true,
   dm_message_received: true,
+  club_join_approved: true,
 };
 
 async function getUserPrefs(userId) {
@@ -50,6 +51,14 @@ function renderTemplate(templateId, templateData) {
       const subject = `Join request for ${clubName}`;
       const text = `${requesterName}${requesterEmail ? ' <' + requesterEmail + '>' : ''} requested to join ${clubName}.\n\nReview and approve/reject: ${reviewUrl}`;
       const html = `<p><strong>${requesterName}</strong>${requesterEmail ? ' &lt;' + requesterEmail + '&gt;' : ''} requested to join <strong>${clubName}</strong>.</p>\n<p><a href="${reviewUrl}">Review and approve/reject</a></p>`;
+      return { subject, text, html };
+    }
+    case 'club_join_approved': {
+      const { clubName = 'a book club', clubUrl = '' } = templateData || {};
+      const brand = process.env.BRAND_NAME || 'BookClub';
+      const subject = `Your request to join "${clubName}" has been approved`;
+      const text = `Great news! Your request to join the book club "${clubName}" on ${brand} has been approved. You can now access the club.${clubUrl ? '\n\nVisit the club: ' + clubUrl : ''}`;
+      const html = `<p>Great news! Your request to join the book club <strong>${clubName}</strong> on ${brand} has been approved.</p><p>You can now access the club.${clubUrl ? ' <a href="' + clubUrl + '">Visit the club</a>' : ''}</p>`;
       return { subject, text, html };
     }
     case 'dm_message_received': {


### PR DESCRIPTION
- Add club_join_approved notification type to DEFAULT_PREFS
- Add club_join_approved email template in renderTemplate
- Send email to approved user in approveRequest handler after DB update
- Notification failure is caught and logged, does not break the approval response